### PR TITLE
feat(cli): add typer-based CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,32 @@ The agent operates in a **capture → reason → act** loop:
 
 Grid-based targeting is model-agnostic, token-efficient, and more precise than raw coordinate prediction. For dense UIs, adaptive zoom refines to sub-cell precision.
 
+## Usage
+
+```bash
+assistant capture                # screenshot of primary monitor
+assistant capture --grid         # with labeled grid overlay
+assistant capture --monitor 0    # all monitors combined
+assistant monitors               # list available monitors
+assistant --version
+```
+
 ## Project Structure
 
 ```
 src/assistant/       # Reusable library — screen capture, input, vision, agent loop
 automations/         # Personal automation scripts built on the library
 tests/               # Mirrors src/ structure
-docs/                # Conventions, structure map, brainstorming
+docs/                # Conventions, brainstorming
 ```
 
 ## Roadmap
 
 | Phase | What | Status |
 |-------|------|--------|
-| 1 | Screen capture (mss + PIL) | Next |
-| 2 | CLI (typer) | Planned |
-| 3 | AI screen interaction (input + vision + agent loop) | Planned |
+| 1 | Screen capture (mss + PIL) | Done |
+| 2 | CLI (typer) | Done |
+| 3 | AI screen interaction (input + vision + agent loop) | Next |
 | 4 | Claude Code skills | Planned |
 | 5 | Memory / RAG (SQLite FTS5) | Planned |
 
@@ -39,9 +49,9 @@ See [docs/BRAINSTORMING.md](docs/BRAINSTORMING.md) for architecture decisions an
 Requires Python 3.12+. Uses [uv](https://docs.astral.sh/uv/) for package management.
 
 ```bash
-uv pip install -e ".[dev]"    # install
-ruff check . && ruff format . # lint + format
-pytest                         # test
+uv pip install -e ".[dev]"        # install
+uv run ruff check . && uv run ruff format .  # lint + format
+uv run pytest                      # test
 ```
 
 See [docs/CONVENTIONS.md](docs/CONVENTIONS.md) for the full workflow guide (git, commits, testing, style).

--- a/main.py
+++ b/main.py
@@ -1,6 +1,0 @@
-def main():
-    print("Hello from assistant!")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ requires-python = ">=3.12"
 dependencies = [
     "mss>=9.0",
     "Pillow>=10.0",
+    "typer>=0.9.0",
 ]
+
+[project.scripts]
+assistant = "assistant.cli:app"
 
 [project.optional-dependencies]
 dev = [
@@ -37,7 +41,6 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"main.py" = ["T20"]
 "scripts/*" = ["T20"]  # demo/utility scripts can print
 
 [tool.ruff.lint.isort]

--- a/src/assistant/__main__.py
+++ b/src/assistant/__main__.py
@@ -1,0 +1,5 @@
+"""Enable running the assistant CLI with: python -m assistant"""
+
+from assistant.cli import app
+
+app()

--- a/src/assistant/cli.py
+++ b/src/assistant/cli.py
@@ -1,0 +1,66 @@
+"""CLI interface for the assistant library.
+
+Wraps the screen capture module (and future modules) in a typer-based CLI.
+Entry point configured in pyproject.toml as 'assistant'.
+"""
+
+import logging
+from typing import Annotated
+
+import typer
+
+app = typer.Typer(help="Computer control agent with vision-based screen understanding.")
+logger = logging.getLogger(__name__)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        from assistant import __version__
+
+        typer.echo(f"assistant {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Annotated[
+        bool | None,
+        typer.Option("--version", callback=_version_callback, is_eager=True),
+    ] = None,
+) -> None:
+    """Computer control agent with vision-based screen understanding."""
+
+
+@app.command()
+def capture(
+    monitor: int = typer.Option(1, help="Monitor index (0=all, 1=primary, 2+=additional)."),
+    label: str = typer.Option("full", help="Label for the saved file."),
+    grid: bool = typer.Option(False, help="Overlay a labeled grid on the screenshot."),
+    cols: int = typer.Option(10, help="Grid columns (only with --grid)."),
+    rows: int = typer.Option(8, help="Grid rows (only with --grid)."),
+    output: str | None = typer.Option(None, help="Output directory override."),
+) -> None:
+    """Capture a screenshot and save it."""
+    from pathlib import Path
+
+    from assistant.screen import capture_screen, overlay_grid, save_capture
+
+    img = capture_screen(monitor=monitor)
+
+    if grid:
+        img = overlay_grid(img, cols=cols, rows=rows)
+        label = f"{label}_grid_{cols}x{rows}"
+
+    directory = Path(output) if output else None
+    path = save_capture(img, label=label, directory=directory)
+    typer.echo(f"Saved: {path}")
+
+
+@app.command()
+def monitors() -> None:
+    """List available monitors and their geometry."""
+    from assistant.screen import list_monitors
+
+    for i, m in enumerate(list_monitors()):
+        tag = "combined" if i == 0 else f"monitor {i}"
+        typer.echo(f"  [{i}] {tag}: {m['width']}x{m['height']} at ({m['left']},{m['top']})")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,81 @@
+"""Tests for the CLI interface."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from assistant.cli import app
+from tests.conftest import make_fake_monitors, make_fake_screenshot
+
+runner = CliRunner()
+
+
+def test_version():
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "assistant" in result.stdout
+    assert "0.1.0" in result.stdout
+
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "capture" in result.stdout
+    assert "monitors" in result.stdout
+
+
+@patch("assistant.screen.mss.mss")
+def test_monitors(mock_mss):
+    sct = mock_mss.return_value.__enter__.return_value
+    sct.monitors = make_fake_monitors()
+
+    result = runner.invoke(app, ["monitors"])
+
+    assert result.exit_code == 0
+    assert "combined" in result.stdout
+    assert "monitor 1" in result.stdout
+    assert "1920x1080" in result.stdout
+
+
+@patch("assistant.screen.mss.mss")
+def test_capture_saves_file(mock_mss, tmp_path):
+    sct = mock_mss.return_value.__enter__.return_value
+    sct.monitors = make_fake_monitors()
+    sct.grab.return_value = make_fake_screenshot(1920, 1080)
+
+    result = runner.invoke(app, ["capture", "--output", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Saved:" in result.stdout
+    # Verify a file was actually created
+    saved_files = list(tmp_path.glob("*.png"))
+    assert len(saved_files) == 1
+
+
+@patch("assistant.screen.mss.mss")
+def test_capture_with_grid(mock_mss, tmp_path):
+    sct = mock_mss.return_value.__enter__.return_value
+    sct.monitors = make_fake_monitors()
+    sct.grab.return_value = make_fake_screenshot(1920, 1080)
+
+    result = runner.invoke(app, ["capture", "--grid", "--output", str(tmp_path)])
+
+    assert result.exit_code == 0
+    # Grid label should appear in filename
+    saved_files = list(tmp_path.glob("*grid*.png"))
+    assert len(saved_files) == 1
+
+
+@patch("assistant.screen.mss.mss")
+def test_capture_custom_label(mock_mss, tmp_path):
+    sct = mock_mss.return_value.__enter__.return_value
+    sct.monitors = make_fake_monitors()
+    sct.grab.return_value = make_fake_screenshot(1920, 1080)
+
+    result = runner.invoke(app, ["capture", "--label", "debug", "--output", str(tmp_path)])
+
+    assert result.exit_code == 0
+    saved_files = list(tmp_path.glob("*debug*.png"))
+    assert len(saved_files) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,22 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "assistant"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mss" },
     { name = "pillow" },
+    { name = "typer" },
 ]
 
 [package.optional-dependencies]
@@ -23,8 +33,21 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "typer", specifier = ">=0.9.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
 
 [[package]]
 name = "colorama"
@@ -42,6 +65,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -166,6 +210,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
@@ -188,4 +245,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
     { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
     { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]


### PR DESCRIPTION
## Summary
- `assistant capture` — screenshot with --monitor, --label, --grid, --output options
- `assistant monitors` — list available monitors with geometry
- `assistant --version` — show package version
- Entry point in pyproject.toml, python -m assistant support
- Replaces stub main.py
- Usage section added to README
- Tested with typer CliRunner (6 tests)

Closes #5