### PR TITLE
feat(vision): add local and cloud vision providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,5 +84,6 @@ The library starts flat — modules are added as we build them. Structure emerge
 - After completing a feature: remind to commit.
 - After completing a feature or set of changes: **provide a review plan** — a step-by-step checklist for the user to code-review and hand-test the changes. Include: files to read in order, test commands, manual verification steps, and edge cases to try.
 - Before starting work: check which branch we're on and whether it's the right one.
+- Every feature must be linked to a GitHub Issue. If no issue exists, create one before starting work. Work on the branch that matches the feature scope — don't add unrelated features to an existing branch.
 - When in doubt about scope, ask — don't expand silently.
 - Do not commit unless the user explicitly tells you to.

--- a/docs/BRAINSTORMING.md
+++ b/docs/BRAINSTORMING.md
@@ -335,3 +335,39 @@ One pipeline, multiple domain-specific plugins:
 | Copilot      | 28-day expiry + citation validation | Elegant staleness handling      |
 | Mem0         | Triple store (vector + graph + KV)  | Captures relationships          |
 | Letta/MemGPT | LLM self-manages memory via tools   | Agent controls its own context  |
+
+---
+
+## Future Ideas & Reminders
+
+### Image Comparison for Failure Detection
+
+Use PIL `ImageChops.difference()` to detect whether an action changed the screen — instant, CPU-only, no vision model call. Use cases:
+- **Stuck detection**: screen unchanged after action → retry or report stuck
+- **Wait-for-load**: compare screenshots until stable (animation finished)
+- **Skip unnecessary vision calls**: if nothing changed, don't re-analyze
+
+### Orchestration Strategy Versioning
+
+Store different orchestration strategies as versioned configs so we can A/B test them:
+
+```
+automations/strategies/
+  simple_click/v1.yaml       # single action per step, basic grid
+  form_filling/v1.yaml       # task-specific: fill forms
+  form_filling/v2.yaml       # improved version
+```
+
+Each strategy defines: prompt template, grid density, model to use, max iterations, verification method. Load by name in the agent loop. Enables comparison between approaches (e.g., "v1: single model" vs "v2: planner + executor" vs "v3: multi-model routing").
+
+### Reference: hermes-agent (NousResearch)
+
+https://github.com/NousResearch/hermes-agent — Notable patterns:
+- **Smart model routing**: detects complexity (code blocks, URLs, keywords) to route cheap vs expensive models
+- **Memory prefetching**: async context assembly before each turn with fence tags
+- **Resilient composition**: memory failures degrade gracefully, don't block execution
+- **Metadata-driven skill discovery**: YAML frontmatter for lightweight loading
+
+### Scripts Refinement
+
+Demo scripts (`demo_vision.py`, `demo_agent_interactive.py`) need updating after OpenRouter migration. Defer to later — functional but reference old defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "typer>=0.9.0",
     "pyautogui>=0.9.54",
     "google-genai>=1.0",
+    "ollama>=0.4.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "Pillow>=10.0",
     "typer>=0.9.0",
     "pyautogui>=0.9.54",
-    "google-genai>=1.0",
+    "openai>=1.0",
     "ollama>=0.4.0",
 ]
 

--- a/scripts/demo_agent_interactive.py
+++ b/scripts/demo_agent_interactive.py
@@ -2,15 +2,24 @@
 
 Run with Ollama:  uv run python scripts/demo_agent_interactive.py
 Run with Gemini:  uv run python scripts/demo_agent_interactive.py --provider gemini
+Stream output:    uv run python scripts/demo_agent_interactive.py --stream
 
 Captures screen, sends to model with a task, displays the response,
 and loops until the user types 'quit'.
 """
 
 import argparse
+import base64
+import os
 
+from assistant.config import DEFAULT_MODELS, DEFAULT_OLLAMA_HOST
 from assistant.screen import capture_screen, overlay_grid, save_capture
-from assistant.vision import analyze_screenshot
+from assistant.vision import (
+    GRID_ANALYSIS_PROMPT,
+    _image_to_bytes,
+    _parse_response,
+    analyze_screenshot,
+)
 
 
 def parse_args():
@@ -21,16 +30,56 @@ def parse_args():
     parser.add_argument("--cols", type=int, default=10, help="Grid columns")
     parser.add_argument("--rows", type=int, default=8, help="Grid rows")
     parser.add_argument("--save-grid", action="store_true", help="Save annotated screenshots")
+    parser.add_argument("--stream", action="store_true", help="Stream model output token by token")
     return parser.parse_args()
+
+
+def _stream_ollama(image_bytes, prompt, model):
+    """Call Ollama with streaming enabled, print tokens as they arrive."""
+    import httpx
+
+    host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt, "images": [image_b64]}],
+        "stream": True,
+    }
+
+    full_response = ""
+    print("\n--- Model output ---")
+    try:
+        with httpx.stream("POST", f"{host}/api/chat", json=payload, timeout=120.0) as response:
+            response.raise_for_status()
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                import json
+
+                chunk = json.loads(line)
+                token = chunk.get("message", {}).get("content", "")
+                if token:
+                    print(token, end="", flush=True)
+                    full_response += token
+    except httpx.ConnectError:
+        print(f"\n  ERROR: Cannot connect to Ollama at {host}. Is it running?")
+        return None
+
+    print("\n--- End output ---\n")
+    return _parse_response(full_response)
 
 
 def main():
     args = parse_args()
 
+    model = args.model or DEFAULT_MODELS.get(args.provider, "unknown")
     print(f"Provider: {args.provider}")
-    print(f"Model: {args.model or '(default)'}")
+    print(f"Model: {model}")
     print(f"Monitor: {args.monitor}")
     print(f"Grid: {args.cols}x{args.rows}")
+    if args.stream:
+        print("Streaming: ON")
     print("Type a task and press Enter. Type 'quit' to exit.\n")
 
     while True:
@@ -53,23 +102,43 @@ def main():
             print(f"  Grid saved: {path}")
 
         print(f"Sending to {args.provider}...")
-        try:
-            response = analyze_screenshot(
-                img,
-                task=task,
-                provider=args.provider,
-                model=args.model,
-                grid_cols=args.cols,
-                grid_rows=args.rows,
-            )
-        except ConnectionError as e:
-            print(f"  ERROR: {e}")
-            continue
-        except ValueError as e:
-            print(f"  ERROR: {e}")
-            continue
 
-        print(f"\n  Reasoning:   {response.reasoning}")
+        # Streaming mode: call Ollama directly with stream=True
+        if args.stream and args.provider == "ollama":
+            annotated = overlay_grid(img, cols=args.cols, rows=args.rows)
+            image_bytes = _image_to_bytes(annotated)
+
+            max_col = chr(64 + args.cols)
+            prompt = GRID_ANALYSIS_PROMPT.format(
+                cols=args.cols,
+                rows=args.rows,
+                max_col=max_col,
+                max_row=args.rows,
+                task=task,
+                history_section="No previous actions.",
+            )
+
+            response = _stream_ollama(image_bytes, prompt, model)
+            if response is None:
+                continue
+        else:
+            try:
+                response = analyze_screenshot(
+                    img,
+                    task=task,
+                    provider=args.provider,
+                    model=args.model,
+                    grid_cols=args.cols,
+                    grid_rows=args.rows,
+                )
+            except ConnectionError as e:
+                print(f"  ERROR: {e}")
+                continue
+            except ValueError as e:
+                print(f"  ERROR: {e}")
+                continue
+
+        print(f"  Reasoning:   {response.reasoning}")
         print(f"  Action:      {response.action}")
         print(f"  Target:      {response.target}")
         print(f"  Text:        {response.text}")

--- a/scripts/demo_agent_interactive.py
+++ b/scripts/demo_agent_interactive.py
@@ -1,0 +1,81 @@
+"""Interactive demo of the vision module.
+
+Run with Ollama:  uv run python scripts/demo_agent_interactive.py
+Run with Gemini:  uv run python scripts/demo_agent_interactive.py --provider gemini
+
+Captures screen, sends to model with a task, displays the response,
+and loops until the user types 'quit'.
+"""
+
+import argparse
+
+from assistant.screen import capture_screen, overlay_grid, save_capture
+from assistant.vision import analyze_screenshot
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Interactive agent demo")
+    parser.add_argument("--provider", default="ollama", help="Vision provider (default: ollama)")
+    parser.add_argument("--model", default=None, help="Model name (default: provider default)")
+    parser.add_argument("--monitor", type=int, default=1, help="Monitor index")
+    parser.add_argument("--cols", type=int, default=10, help="Grid columns")
+    parser.add_argument("--rows", type=int, default=8, help="Grid rows")
+    parser.add_argument("--save-grid", action="store_true", help="Save annotated screenshots")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    print(f"Provider: {args.provider}")
+    print(f"Model: {args.model or '(default)'}")
+    print(f"Monitor: {args.monitor}")
+    print(f"Grid: {args.cols}x{args.rows}")
+    print("Type a task and press Enter. Type 'quit' to exit.\n")
+
+    while True:
+        try:
+            task = input("Task> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nBye.")
+            break
+
+        if not task or task.lower() in ("quit", "exit", "q"):
+            print("Bye.")
+            break
+
+        print("Capturing screen...")
+        img = capture_screen(monitor=args.monitor)
+
+        if args.save_grid:
+            grid_img = overlay_grid(img, cols=args.cols, rows=args.rows)
+            path = save_capture(grid_img, label="interactive_grid")
+            print(f"  Grid saved: {path}")
+
+        print(f"Sending to {args.provider}...")
+        try:
+            response = analyze_screenshot(
+                img,
+                task=task,
+                provider=args.provider,
+                model=args.model,
+                grid_cols=args.cols,
+                grid_rows=args.rows,
+            )
+        except ConnectionError as e:
+            print(f"  ERROR: {e}")
+            continue
+        except ValueError as e:
+            print(f"  ERROR: {e}")
+            continue
+
+        print(f"\n  Reasoning:   {response.reasoning}")
+        print(f"  Action:      {response.action}")
+        print(f"  Target:      {response.target}")
+        print(f"  Text:        {response.text}")
+        print(f"  Confidence:  {response.confidence}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/demo_agent_interactive.py
+++ b/scripts/demo_agent_interactive.py
@@ -30,6 +30,7 @@ def parse_args():
     parser.add_argument("--rows", type=int, default=8, help="Grid rows")
     parser.add_argument("--save-grid", action="store_true", help="Save annotated screenshots")
     parser.add_argument("--stream", action="store_true", help="Stream model output token by token")
+    parser.add_argument("--verbose", action="store_true", help="Show debug logs from all modules")
     return parser.parse_args()
 
 
@@ -63,7 +64,12 @@ def _stream_ollama(image_bytes, prompt, model):
 
 
 def main():
+    import logging
+
     args = parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
 
     model = args.model or DEFAULT_MODELS.get(args.provider, "unknown")
     print(f"Provider: {args.provider}")

--- a/scripts/demo_agent_interactive.py
+++ b/scripts/demo_agent_interactive.py
@@ -69,7 +69,9 @@ def main():
     args = parse_args()
 
     if args.verbose:
-        logging.basicConfig(level=logging.DEBUG, format="%(name)s: %(message)s")
+        # Only enable debug for our modules — not httpx/openai which log full HTTP payloads
+        logging.basicConfig(level=logging.WARNING, format="%(name)s: %(message)s")
+        logging.getLogger("assistant").setLevel(logging.DEBUG)
 
     model = args.model or DEFAULT_MODELS.get(args.provider, "unknown")
     print(f"Provider: {args.provider}")

--- a/scripts/demo_agent_interactive.py
+++ b/scripts/demo_agent_interactive.py
@@ -10,9 +10,8 @@ and loops until the user types 'quit'.
 
 import argparse
 import base64
-import os
 
-from assistant.config import DEFAULT_MODELS, DEFAULT_OLLAMA_HOST
+from assistant.config import DEFAULT_MODELS
 from assistant.screen import capture_screen, overlay_grid, save_capture
 from assistant.vision import (
     GRID_ANALYSIS_PROMPT,
@@ -35,36 +34,29 @@ def parse_args():
 
 
 def _stream_ollama(image_bytes, prompt, model):
-    """Call Ollama with streaming enabled, print tokens as they arrive."""
-    import httpx
+    """Call Ollama with streaming via the official package. Tokens print as they arrive."""
+    from ollama import chat
 
-    host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
     image_b64 = base64.b64encode(image_bytes).decode("ascii")
-
-    payload = {
-        "model": model,
-        "messages": [{"role": "user", "content": prompt, "images": [image_b64]}],
-        "stream": True,
-    }
 
     full_response = ""
     print("\n--- Model output ---")
     try:
-        with httpx.stream("POST", f"{host}/api/chat", json=payload, timeout=120.0) as response:
-            response.raise_for_status()
-            for line in response.iter_lines():
-                if not line:
-                    continue
-                import json
-
-                chunk = json.loads(line)
-                token = chunk.get("message", {}).get("content", "")
-                if token:
-                    print(token, end="", flush=True)
-                    full_response += token
-    except httpx.ConnectError:
-        print(f"\n  ERROR: Cannot connect to Ollama at {host}. Is it running?")
-        return None
+        stream = chat(
+            model=model,
+            messages=[{"role": "user", "content": prompt, "images": [image_b64]}],
+            stream=True,
+        )
+        for chunk in stream:
+            token = chunk.get("message", {}).get("content", "")
+            if token:
+                print(token, end="", flush=True)
+                full_response += token
+    except Exception as e:
+        if "connect" in str(e).lower():
+            print("\n  ERROR: Cannot connect to Ollama. Is it running?")
+            return None
+        raise
 
     print("\n--- End output ---\n")
     return _parse_response(full_response)
@@ -103,7 +95,7 @@ def main():
 
         print(f"Sending to {args.provider}...")
 
-        # Streaming mode: call Ollama directly with stream=True
+        # Streaming mode: use ollama package with stream=True
         if args.stream and args.provider == "ollama":
             annotated = overlay_grid(img, cols=args.cols, rows=args.rows)
             image_bytes = _image_to_bytes(annotated)

--- a/src/assistant/agent.py
+++ b/src/assistant/agent.py
@@ -63,6 +63,7 @@ def run_agent(
     grid_cols: int = 10,
     grid_rows: int = 8,
     provider: str = "gemini",
+    model: str | None = None,
     dry_run: bool = False,
 ) -> Session:
     """Run the agent loop to accomplish a task.
@@ -75,6 +76,7 @@ def run_agent(
         grid_cols: Grid columns for overlay.
         grid_rows: Grid rows for overlay.
         provider: Vision model provider.
+        model: Model name override (default depends on provider).
         dry_run: If True, analyze but don't execute actions.
 
     Returns:
@@ -94,6 +96,7 @@ def run_agent(
             "started_at": session.started_at,
             "dry_run": dry_run,
             "provider": provider,
+            "model": model,
         },
     )
 
@@ -124,6 +127,7 @@ def run_agent(
             task=task,
             history=history,
             provider=provider,
+            model=model,
             grid_cols=grid_cols,
             grid_rows=grid_rows,
         )

--- a/src/assistant/cli.py
+++ b/src/assistant/cli.py
@@ -115,7 +115,7 @@ def run(
     max_iterations: int = typer.Option(20, help="Maximum loop iterations."),
     timeout: float = typer.Option(300.0, help="Timeout in seconds."),
     monitor: int = typer.Option(1, help="Monitor to capture."),
-    provider: str = typer.Option("gemini", help="Vision model provider."),
+    provider: str = typer.Option("openrouter", help="Vision model provider."),
     model: str | None = typer.Option(None, help="Model name (default depends on provider)."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Analyze but don't execute actions."),
     grid_cols: int = typer.Option(10, help="Grid columns."),

--- a/src/assistant/cli.py
+++ b/src/assistant/cli.py
@@ -116,6 +116,7 @@ def run(
     timeout: float = typer.Option(300.0, help="Timeout in seconds."),
     monitor: int = typer.Option(1, help="Monitor to capture."),
     provider: str = typer.Option("gemini", help="Vision model provider."),
+    model: str | None = typer.Option(None, help="Model name (default depends on provider)."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Analyze but don't execute actions."),
     grid_cols: int = typer.Option(10, help="Grid columns."),
     grid_rows: int = typer.Option(8, help="Grid rows."),
@@ -134,6 +135,7 @@ def run(
         grid_cols=grid_cols,
         grid_rows=grid_rows,
         provider=provider,
+        model=model,
         dry_run=dry_run,
     )
 

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -7,11 +7,11 @@ in one place without hunting through multiple modules.
 # -- Vision providers --
 
 # Default provider when none is specified
-DEFAULT_VISION_PROVIDER = "gemini"
+DEFAULT_VISION_PROVIDER = "openrouter"
 
 # Default model per provider — used when --model is not passed
 DEFAULT_MODELS = {
-    "gemini": "gemini-flash-latest",
+    "openrouter": "google/gemini-flash-latest",
     "ollama": "qwen3-vl:4b",
 }
 

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -1,0 +1,19 @@
+"""Centralized configuration for model defaults and provider settings.
+
+All model names and provider defaults live here so they can be changed
+in one place without hunting through multiple modules.
+"""
+
+# -- Vision providers --
+
+# Default provider when none is specified
+DEFAULT_VISION_PROVIDER = "gemini"
+
+# Default model per provider — used when --model is not passed
+DEFAULT_MODELS = {
+    "gemini": "gemini-flash-latest",
+    "ollama": "qwen3-vl:8b",
+}
+
+# Ollama connection
+DEFAULT_OLLAMA_HOST = "http://localhost:11434"

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -12,7 +12,7 @@ DEFAULT_VISION_PROVIDER = "gemini"
 # Default model per provider — used when --model is not passed
 DEFAULT_MODELS = {
     "gemini": "gemini-flash-latest",
-    "ollama": "qwen3-vl:8b",
+    "ollama": "qwen3-vl:4b",
 }
 
 # Ollama connection

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -15,5 +15,10 @@ DEFAULT_MODELS = {
     "ollama": "qwen3-vl:4b",
 }
 
+# Fallback models when the primary is rate-limited
+FALLBACK_MODELS = {
+    "openrouter": "nvidia/nemotron-nano-12b-v2-vl:free",
+}
+
 # Ollama connection
 DEFAULT_OLLAMA_HOST = "http://localhost:11434"

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -11,7 +11,7 @@ DEFAULT_VISION_PROVIDER = "openrouter"
 
 # Default model per provider — used when --model is not passed
 DEFAULT_MODELS = {
-    "openrouter": "google/gemini-2.0-flash-exp:free",
+    "openrouter": "google/gemma-4-31b-it:free",
     "ollama": "qwen3-vl:4b",
 }
 

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -11,7 +11,7 @@ DEFAULT_VISION_PROVIDER = "openrouter"
 
 # Default model per provider — used when --model is not passed
 DEFAULT_MODELS = {
-    "openrouter": "google/gemini-3.1-flash-lite-preview",
+    "openrouter": "google/gemini-2.0-flash-exp:free",
     "ollama": "qwen3-vl:4b",
 }
 

--- a/src/assistant/config.py
+++ b/src/assistant/config.py
@@ -11,7 +11,7 @@ DEFAULT_VISION_PROVIDER = "openrouter"
 
 # Default model per provider — used when --model is not passed
 DEFAULT_MODELS = {
-    "openrouter": "google/gemini-flash-latest",
+    "openrouter": "google/gemini-3.1-flash-lite-preview",
     "ollama": "qwen3-vl:4b",
 }
 

--- a/src/assistant/vision.py
+++ b/src/assistant/vision.py
@@ -205,6 +205,7 @@ def _analyze_openrouter(
 
     response = client.chat.completions.create(
         model=model,
+        max_tokens=1024,
         messages=[
             {
                 "role": "user",

--- a/src/assistant/vision.py
+++ b/src/assistant/vision.py
@@ -224,38 +224,30 @@ def _analyze_ollama(
 ) -> VisionResponse:
     """Send image + prompt to a local Ollama instance and parse the response.
 
-    Ollama must be running. Configure host via OLLAMA_HOST env var
-    (default: http://localhost:11434).
+    Uses the official ollama Python package. Ollama must be running.
+    Configure host via OLLAMA_HOST env var (default: http://localhost:11434).
     """
     import base64
 
-    import httpx
-
-    host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
-    url = f"{host}/api/chat"
+    from ollama import chat
 
     image_b64 = base64.b64encode(image_bytes).decode("ascii")
 
-    payload = {
-        "model": model,
-        "messages": [
-            {
-                "role": "user",
-                "content": prompt,
-                "images": [image_b64],
-            }
-        ],
-        "stream": False,
-    }
-
     try:
-        response = httpx.post(url, json=payload, timeout=120.0)
-        response.raise_for_status()
-    except httpx.ConnectError as e:
-        raise ConnectionError(
-            f"Cannot connect to Ollama at {host}. Is Ollama running? Start it with: ollama serve"
-        ) from e
+        response = chat(
+            model=model,
+            messages=[{"role": "user", "content": prompt, "images": [image_b64]}],
+        )
+    except Exception as e:
+        # ollama raises ConnectionError or httpx.ConnectError when server is down
+        if "connect" in str(e).lower():
+            host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
+            raise ConnectionError(
+                f"Cannot connect to Ollama at {host}. "
+                "Is Ollama running? Start it with: ollama serve"
+            ) from e
+        raise
 
-    raw_text = response.json()["message"]["content"]
+    raw_text = response["message"]["content"]
     logger.debug("Ollama response (%s): %s", model, raw_text[:200])
     return _parse_response(raw_text)

--- a/src/assistant/vision.py
+++ b/src/assistant/vision.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from openai import OpenAI
 from PIL import Image
 
-from assistant.config import DEFAULT_MODELS, DEFAULT_OLLAMA_HOST
+from assistant.config import DEFAULT_MODELS, DEFAULT_OLLAMA_HOST, FALLBACK_MODELS
 from assistant.screen import overlay_grid
 
 logger = logging.getLogger(__name__)
@@ -194,7 +194,7 @@ def _analyze_openrouter(
     """Send image + prompt via OpenRouter (OpenAI-compatible API).
 
     Requires OPENROUTER_API_KEY environment variable.
-    Supports any vision model available on OpenRouter.
+    Falls back to a secondary model if the primary is rate-limited.
     """
     api_key = os.environ.get("OPENROUTER_API_KEY")
     if not api_key:
@@ -203,28 +203,36 @@ def _analyze_openrouter(
     client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
     image_b64 = base64.b64encode(image_bytes).decode("utf-8")
 
-    response = client.chat.completions.create(
-        model=model,
-        max_tokens=1024,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": prompt},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
-                    },
-                ],
-            }
-        ],
-    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                },
+            ],
+        }
+    ]
+
+    try:
+        response = client.chat.completions.create(model=model, messages=messages)
+    except Exception as e:
+        # On rate limit (429), try the fallback model
+        fallback = FALLBACK_MODELS.get("openrouter")
+        if "429" in str(e) and fallback and fallback != model:
+            logger.warning("Rate limited on %s, falling back to %s", model, fallback)
+            response = client.chat.completions.create(model=fallback, messages=messages)
+        else:
+            raise
 
     raw_text = response.choices[0].message.content
     if raw_text is None:
         raise ValueError(f"OpenRouter ({model}): No response")
 
-    logger.debug("OpenRouter response (%s): %s", model, raw_text[:200])
+    used_model = response.model or model
+    logger.debug("OpenRouter response (%s): %s", used_model, raw_text[:200])
     return _parse_response(raw_text)
 
 

--- a/src/assistant/vision.py
+++ b/src/assistant/vision.py
@@ -4,11 +4,9 @@ Sends annotated screenshots to vision models and parses structured
 action responses. Supports grid-based targeting where the model
 references cell labels (e.g., "B3") instead of raw pixel coordinates.
 
-Provider is Gemini by default. Additional providers can be added
-by implementing a _analyze_{provider} function and adding an elif
-in analyze_screenshot().
-
-Requires GEMINI_API_KEY or GOOGLE_API_KEY environment variable.
+Supported providers:
+- "gemini": Google Gemini API (requires GEMINI_API_KEY or GOOGLE_API_KEY env var)
+- "ollama": Local Ollama instance (requires Ollama running, configurable via OLLAMA_HOST)
 """
 
 import io
@@ -79,6 +77,7 @@ def analyze_screenshot(
     task: str,
     history: list[dict] | None = None,
     provider: str = "gemini",
+    model: str | None = None,
     grid_cols: int = 10,
     grid_rows: int = 8,
 ) -> VisionResponse:
@@ -92,7 +91,8 @@ def analyze_screenshot(
         task: Natural language description of what to accomplish.
         history: Previous steps for context (list of dicts with
             "action", "target", "reasoning" keys).
-        provider: Vision model provider ("gemini").
+        provider: Vision model provider ("gemini" or "ollama").
+        model: Model name override. Defaults to provider-specific default.
         grid_cols: Grid columns for overlay.
         grid_rows: Grid rows for overlay.
 
@@ -118,9 +118,11 @@ def analyze_screenshot(
     image_bytes = _image_to_bytes(annotated)
 
     if provider == "gemini":
-        return _analyze_gemini(image_bytes, prompt)
+        return _analyze_gemini(image_bytes, prompt, model=model or "gemini-flash-latest")
+    elif provider == "ollama":
+        return _analyze_ollama(image_bytes, prompt, model=model or "qwen2.5vl:7b")
 
-    raise ValueError(f"Unknown vision provider: {provider!r}. Available: gemini")
+    raise ValueError(f"Unknown vision provider: {provider!r}. Available: gemini, ollama")
 
 
 def _format_history(history: list[dict]) -> str:
@@ -152,7 +154,6 @@ def _parse_response(raw_text: str) -> VisionResponse:
     # Strip markdown code fences if present
     if text.startswith("```"):
         lines = text.split("\n")
-        # Remove first line (```json or ```) and last line (```)
         lines = [line for line in lines if not line.strip().startswith("```")]
         text = "\n".join(lines).strip()
 
@@ -192,16 +193,17 @@ def _get_api_key() -> str:
     return key
 
 
-def _analyze_gemini(image_bytes: bytes, prompt: str) -> VisionResponse:
+def _analyze_gemini(
+    image_bytes: bytes, prompt: str, model: str = "gemini-flash-latest"
+) -> VisionResponse:
     """Send image + prompt to Gemini and parse the response."""
     from google import genai
 
     api_key = _get_api_key()
     client = genai.Client(api_key=api_key)
 
-    # Send image as inline data with the prompt
     response = client.models.generate_content(
-        model="gemini-flash-latest",
+        model=model,
         contents=[
             genai.types.Part.from_bytes(data=image_bytes, mime_type="image/png"),
             prompt,
@@ -212,5 +214,47 @@ def _analyze_gemini(image_bytes: bytes, prompt: str) -> VisionResponse:
     if raw_text is None:
         raise ValueError("Gemini: No response")
 
-    logger.debug("Gemini response: %s", raw_text[:200])
+    logger.debug("Gemini response (%s): %s", model, raw_text[:200])
+    return _parse_response(raw_text)
+
+
+def _analyze_ollama(
+    image_bytes: bytes, prompt: str, model: str = "qwen2.5vl:7b"
+) -> VisionResponse:
+    """Send image + prompt to a local Ollama instance and parse the response.
+
+    Ollama must be running. Configure host via OLLAMA_HOST env var
+    (default: http://localhost:11434).
+    """
+    import base64
+
+    import httpx
+
+    host = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+    url = f"{host}/api/chat"
+
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+
+    payload = {
+        "model": model,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt,
+                "images": [image_b64],
+            }
+        ],
+        "stream": False,
+    }
+
+    try:
+        response = httpx.post(url, json=payload, timeout=120.0)
+        response.raise_for_status()
+    except httpx.ConnectError as e:
+        raise ConnectionError(
+            f"Cannot connect to Ollama at {host}. Is Ollama running? Start it with: ollama serve"
+        ) from e
+
+    raw_text = response.json()["message"]["content"]
+    logger.debug("Ollama response (%s): %s", model, raw_text[:200])
     return _parse_response(raw_text)

--- a/src/assistant/vision.py
+++ b/src/assistant/vision.py
@@ -5,16 +5,19 @@ action responses. Supports grid-based targeting where the model
 references cell labels (e.g., "B3") instead of raw pixel coordinates.
 
 Supported providers:
-- "gemini": Google Gemini API (requires GEMINI_API_KEY or GOOGLE_API_KEY env var)
+- "openrouter": OpenAI-compatible API via OpenRouter (requires OPENROUTER_API_KEY env var).
+    Supports 200+ models including Gemini, Claude, Llama, etc.
 - "ollama": Local Ollama instance (requires Ollama running, configurable via OLLAMA_HOST)
 """
 
+import base64
 import io
 import json
 import logging
 import os
 from dataclasses import dataclass
 
+from openai import OpenAI
 from PIL import Image
 
 from assistant.config import DEFAULT_MODELS, DEFAULT_OLLAMA_HOST
@@ -77,7 +80,7 @@ def analyze_screenshot(
     image: Image.Image,
     task: str,
     history: list[dict] | None = None,
-    provider: str = "gemini",
+    provider: str = "openrouter",
     model: str | None = None,
     grid_cols: int = 10,
     grid_rows: int = 8,
@@ -92,7 +95,7 @@ def analyze_screenshot(
         task: Natural language description of what to accomplish.
         history: Previous steps for context (list of dicts with
             "action", "target", "reasoning" keys).
-        provider: Vision model provider ("gemini" or "ollama").
+        provider: Vision model provider ("openrouter" or "ollama").
         model: Model name override. Defaults to provider-specific default.
         grid_cols: Grid columns for overlay.
         grid_rows: Grid rows for overlay.
@@ -115,15 +118,16 @@ def analyze_screenshot(
         history_section=history_section,
     )
 
-    # Convert image to bytes for the provider
     image_bytes = _image_to_bytes(annotated)
 
-    if provider == "gemini":
-        return _analyze_gemini(image_bytes, prompt, model=model or DEFAULT_MODELS["gemini"])
-    elif provider == "ollama":
-        return _analyze_ollama(image_bytes, prompt, model=model or DEFAULT_MODELS["ollama"])
+    resolved_model = model or DEFAULT_MODELS.get(provider)
 
-    raise ValueError(f"Unknown vision provider: {provider!r}. Available: gemini, ollama")
+    if provider == "openrouter":
+        return _analyze_openrouter(image_bytes, prompt, model=resolved_model)
+    elif provider == "ollama":
+        return _analyze_ollama(image_bytes, prompt, model=resolved_model)
+
+    raise ValueError(f"Unknown vision provider: {provider!r}. Available: openrouter, ollama")
 
 
 def _format_history(history: list[dict]) -> str:
@@ -184,38 +188,42 @@ def _parse_response(raw_text: str) -> VisionResponse:
     )
 
 
-def _get_api_key() -> str:
-    """Get the Gemini API key from environment variables."""
-    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if not key:
-        raise ValueError(
-            "No API key found. Set GEMINI_API_KEY or GOOGLE_API_KEY environment variable."
-        )
-    return key
-
-
-def _analyze_gemini(
-    image_bytes: bytes, prompt: str, model: str = DEFAULT_MODELS["gemini"]
+def _analyze_openrouter(
+    image_bytes: bytes, prompt: str, model: str = DEFAULT_MODELS["openrouter"]
 ) -> VisionResponse:
-    """Send image + prompt to Gemini and parse the response."""
-    from google import genai
+    """Send image + prompt via OpenRouter (OpenAI-compatible API).
 
-    api_key = _get_api_key()
-    client = genai.Client(api_key=api_key)
+    Requires OPENROUTER_API_KEY environment variable.
+    Supports any vision model available on OpenRouter.
+    """
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise ValueError("No API key found. Set OPENROUTER_API_KEY environment variable.")
 
-    response = client.models.generate_content(
+    client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
+    image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+    response = client.chat.completions.create(
         model=model,
-        contents=[
-            genai.types.Part.from_bytes(data=image_bytes, mime_type="image/png"),
-            prompt,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                    },
+                ],
+            }
         ],
     )
 
-    raw_text = response.text
+    raw_text = response.choices[0].message.content
     if raw_text is None:
-        raise ValueError("Gemini: No response")
+        raise ValueError(f"OpenRouter ({model}): No response")
 
-    logger.debug("Gemini response (%s): %s", model, raw_text[:200])
+    logger.debug("OpenRouter response (%s): %s", model, raw_text[:200])
     return _parse_response(raw_text)
 
 
@@ -227,8 +235,6 @@ def _analyze_ollama(
     Uses the official ollama Python package. Ollama must be running.
     Configure host via OLLAMA_HOST env var (default: http://localhost:11434).
     """
-    import base64
-
     from ollama import chat
 
     image_b64 = base64.b64encode(image_bytes).decode("ascii")
@@ -239,7 +245,6 @@ def _analyze_ollama(
             messages=[{"role": "user", "content": prompt, "images": [image_b64]}],
         )
     except Exception as e:
-        # ollama raises ConnectionError or httpx.ConnectError when server is down
         if "connect" in str(e).lower():
             host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
             raise ConnectionError(

--- a/src/assistant/vision.py
+++ b/src/assistant/vision.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 
 from PIL import Image
 
+from assistant.config import DEFAULT_MODELS, DEFAULT_OLLAMA_HOST
 from assistant.screen import overlay_grid
 
 logger = logging.getLogger(__name__)
@@ -118,9 +119,9 @@ def analyze_screenshot(
     image_bytes = _image_to_bytes(annotated)
 
     if provider == "gemini":
-        return _analyze_gemini(image_bytes, prompt, model=model or "gemini-flash-latest")
+        return _analyze_gemini(image_bytes, prompt, model=model or DEFAULT_MODELS["gemini"])
     elif provider == "ollama":
-        return _analyze_ollama(image_bytes, prompt, model=model or "qwen2.5vl:7b")
+        return _analyze_ollama(image_bytes, prompt, model=model or DEFAULT_MODELS["ollama"])
 
     raise ValueError(f"Unknown vision provider: {provider!r}. Available: gemini, ollama")
 
@@ -194,7 +195,7 @@ def _get_api_key() -> str:
 
 
 def _analyze_gemini(
-    image_bytes: bytes, prompt: str, model: str = "gemini-flash-latest"
+    image_bytes: bytes, prompt: str, model: str = DEFAULT_MODELS["gemini"]
 ) -> VisionResponse:
     """Send image + prompt to Gemini and parse the response."""
     from google import genai
@@ -219,7 +220,7 @@ def _analyze_gemini(
 
 
 def _analyze_ollama(
-    image_bytes: bytes, prompt: str, model: str = "qwen2.5vl:7b"
+    image_bytes: bytes, prompt: str, model: str = DEFAULT_MODELS["ollama"]
 ) -> VisionResponse:
     """Send image + prompt to a local Ollama instance and parse the response.
 
@@ -230,7 +231,7 @@ def _analyze_ollama(
 
     import httpx
 
-    host = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+    host = os.environ.get("OLLAMA_HOST", DEFAULT_OLLAMA_HOST)
     url = f"{host}/api/chat"
 
     image_b64 = base64.b64encode(image_bytes).decode("ascii")

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -216,8 +216,10 @@ def test_analyze_ollama_success(mock_post):
     assert result.action == "left_click"
     assert result.target == "C4"
     mock_post.assert_called_once()
-    # Verify model default
-    assert mock_post.call_args.kwargs["json"]["model"] == "qwen3-vl:8b"
+    # Verify it uses the configured default model
+    from assistant.config import DEFAULT_MODELS
+
+    assert mock_post.call_args.kwargs["json"]["model"] == DEFAULT_MODELS["ollama"]
 
 
 @patch("httpx.post", side_effect=httpx.ConnectError("refused"))

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -217,7 +217,7 @@ def test_analyze_ollama_success(mock_post):
     assert result.target == "C4"
     mock_post.assert_called_once()
     # Verify model default
-    assert mock_post.call_args.kwargs["json"]["model"] == "qwen2.5vl:7b"
+    assert mock_post.call_args.kwargs["json"]["model"] == "qwen3-vl:8b"
 
 
 @patch("httpx.post", side_effect=httpx.ConnectError("refused"))

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,8 +1,9 @@
 """Tests for the vision module."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from PIL import Image
 
@@ -113,7 +114,7 @@ def test_format_history_with_steps():
     assert "Typed query" in result
 
 
-# -- analyze_screenshot --
+# -- analyze_screenshot: Gemini --
 
 
 def test_missing_api_key_raises(monkeypatch):
@@ -132,8 +133,7 @@ def test_unknown_provider_raises():
 
 
 @patch("assistant.vision._analyze_gemini")
-def test_analyze_screenshot_calls_gemini(mock_gemini, monkeypatch):
-    monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
+def test_analyze_screenshot_calls_gemini(mock_gemini):
     mock_gemini.return_value = VisionResponse(
         reasoning="test",
         action="done",
@@ -147,3 +147,110 @@ def test_analyze_screenshot_calls_gemini(mock_gemini, monkeypatch):
 
     assert result.action == "done"
     mock_gemini.assert_called_once()
+
+
+# -- analyze_screenshot: Ollama --
+
+
+@patch("assistant.vision._analyze_ollama")
+def test_analyze_screenshot_calls_ollama(mock_ollama):
+    mock_ollama.return_value = VisionResponse(
+        reasoning="test",
+        action="done",
+        target=None,
+        text=None,
+        confidence="high",
+    )
+
+    img = Image.new("RGB", (1024, 768))
+    result = analyze_screenshot(img, task="test task", provider="ollama")
+
+    assert result.action == "done"
+    mock_ollama.assert_called_once()
+
+
+@patch("assistant.vision._analyze_ollama")
+def test_analyze_screenshot_passes_model(mock_ollama):
+    mock_ollama.return_value = VisionResponse(
+        reasoning="test",
+        action="done",
+        target=None,
+        text=None,
+        confidence="high",
+    )
+
+    img = Image.new("RGB", (1024, 768))
+    analyze_screenshot(img, task="test", provider="ollama", model="llava:13b")
+
+    # model should be passed through to the provider
+    call_kwargs = mock_ollama.call_args
+    assert call_kwargs[1]["model"] == "llava:13b"
+
+
+# -- _analyze_ollama --
+
+
+@patch("httpx.post")
+def test_analyze_ollama_success(mock_post):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "message": {
+            "content": json.dumps(
+                {
+                    "reasoning": "I see a button",
+                    "action": "left_click",
+                    "target": "C4",
+                    "text": None,
+                    "confidence": "high",
+                }
+            )
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_post.return_value = mock_response
+
+    from assistant.vision import _analyze_ollama
+
+    result = _analyze_ollama(b"fake-png-bytes", "test prompt")
+
+    assert result.action == "left_click"
+    assert result.target == "C4"
+    mock_post.assert_called_once()
+    # Verify model default
+    assert mock_post.call_args.kwargs["json"]["model"] == "qwen2.5vl:7b"
+
+
+@patch("httpx.post", side_effect=httpx.ConnectError("refused"))
+def test_analyze_ollama_connection_refused(mock_post):
+    from assistant.vision import _analyze_ollama
+
+    with pytest.raises(ConnectionError, match="Cannot connect to Ollama"):
+        _analyze_ollama(b"fake-png-bytes", "test prompt")
+
+
+@patch("httpx.post")
+def test_analyze_ollama_custom_host(mock_post, monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://my-server:11434")
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "message": {
+            "content": json.dumps(
+                {
+                    "reasoning": "test",
+                    "action": "done",
+                    "target": None,
+                    "text": None,
+                    "confidence": "high",
+                }
+            )
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_post.return_value = mock_response
+
+    from assistant.vision import _analyze_ollama
+
+    _analyze_ollama(b"fake-png-bytes", "test prompt")
+
+    call_url = mock_post.call_args[0][0]
+    assert call_url == "http://my-server:11434/api/chat"

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,9 +1,8 @@
 """Tests for the vision module."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import httpx
 import pytest
 from PIL import Image
 
@@ -190,10 +189,9 @@ def test_analyze_screenshot_passes_model(mock_ollama):
 # -- _analyze_ollama --
 
 
-@patch("httpx.post")
-def test_analyze_ollama_success(mock_post):
-    mock_response = MagicMock()
-    mock_response.json.return_value = {
+@patch("ollama.chat")
+def test_analyze_ollama_success(mock_chat):
+    mock_chat.return_value = {
         "message": {
             "content": json.dumps(
                 {
@@ -206,8 +204,6 @@ def test_analyze_ollama_success(mock_post):
             )
         }
     }
-    mock_response.raise_for_status = MagicMock()
-    mock_post.return_value = mock_response
 
     from assistant.vision import _analyze_ollama
 
@@ -215,44 +211,16 @@ def test_analyze_ollama_success(mock_post):
 
     assert result.action == "left_click"
     assert result.target == "C4"
-    mock_post.assert_called_once()
+    mock_chat.assert_called_once()
     # Verify it uses the configured default model
     from assistant.config import DEFAULT_MODELS
 
-    assert mock_post.call_args.kwargs["json"]["model"] == DEFAULT_MODELS["ollama"]
+    assert mock_chat.call_args.kwargs["model"] == DEFAULT_MODELS["ollama"]
 
 
-@patch("httpx.post", side_effect=httpx.ConnectError("refused"))
-def test_analyze_ollama_connection_refused(mock_post):
+@patch("ollama.chat", side_effect=ConnectionError("connection refused"))
+def test_analyze_ollama_connection_refused(mock_chat):
     from assistant.vision import _analyze_ollama
 
     with pytest.raises(ConnectionError, match="Cannot connect to Ollama"):
         _analyze_ollama(b"fake-png-bytes", "test prompt")
-
-
-@patch("httpx.post")
-def test_analyze_ollama_custom_host(mock_post, monkeypatch):
-    monkeypatch.setenv("OLLAMA_HOST", "http://my-server:11434")
-    mock_response = MagicMock()
-    mock_response.json.return_value = {
-        "message": {
-            "content": json.dumps(
-                {
-                    "reasoning": "test",
-                    "action": "done",
-                    "target": None,
-                    "text": None,
-                    "confidence": "high",
-                }
-            )
-        }
-    }
-    mock_response.raise_for_status = MagicMock()
-    mock_post.return_value = mock_response
-
-    from assistant.vision import _analyze_ollama
-
-    _analyze_ollama(b"fake-png-bytes", "test prompt")
-
-    call_url = mock_post.call_args[0][0]
-    assert call_url == "http://my-server:11434/api/chat"

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -113,27 +113,26 @@ def test_format_history_with_steps():
     assert "Typed query" in result
 
 
-# -- analyze_screenshot: Gemini --
+# -- analyze_screenshot: OpenRouter --
 
 
 def test_missing_api_key_raises(monkeypatch):
-    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
 
     img = Image.new("RGB", (100, 100))
-    with pytest.raises(ValueError, match="No API key found"):
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
         analyze_screenshot(img, task="test")
 
 
 def test_unknown_provider_raises():
     img = Image.new("RGB", (100, 100))
     with pytest.raises(ValueError, match="Unknown vision provider"):
-        analyze_screenshot(img, task="test", provider="openai")
+        analyze_screenshot(img, task="test", provider="invalid")
 
 
-@patch("assistant.vision._analyze_gemini")
-def test_analyze_screenshot_calls_gemini(mock_gemini):
-    mock_gemini.return_value = VisionResponse(
+@patch("assistant.vision._analyze_openrouter")
+def test_analyze_screenshot_calls_openrouter(mock_openrouter):
+    mock_openrouter.return_value = VisionResponse(
         reasoning="test",
         action="done",
         target=None,
@@ -145,7 +144,7 @@ def test_analyze_screenshot_calls_gemini(mock_gemini):
     result = analyze_screenshot(img, task="test task")
 
     assert result.action == "done"
-    mock_gemini.assert_called_once()
+    mock_openrouter.assert_called_once()
 
 
 # -- analyze_screenshot: Ollama --


### PR DESCRIPTION
## Summary

Adds two vision providers beyond the original Gemini-only implementation:

- **OpenRouter**: OpenAI-compatible API supporting 200+ models (Gemini, Claude, Llama, etc.). Default: `google/gemma-4-31b-it:free`. Automatic fallback to `nvidia/nemotron-nano-12b-v2-vl:free` on rate limit.
- **Ollama**: Local inference via official ollama Python package. Default: `qwen3-vl:4b`. True token-by-token streaming support.

Also includes:
- `config.py` — centralized model defaults and fallback configuration
- Interactive demo script with `--stream` and `--verbose` flags
- Replaced `google-genai` dependency with `openai` (lighter, more universal)
- Brainstorming doc updated with future ideas (image-diff detection, orchestration versioning, hermes-agent patterns)

## New commands
```
uv run python scripts/demo_agent_interactive.py --provider openrouter
uv run python scripts/demo_agent_interactive.py --provider ollama --stream
uv run python scripts/demo_agent_interactive.py --verbose
```

## Test plan
- [x] `uv run pytest -v` — 58 passed
- [x] OpenRouter: `set OPENROUTER_API_KEY=... && uv run python scripts/demo_agent_interactive.py --provider openrouter`
- [x] Ollama: `uv run python scripts/demo_agent_interactive.py --provider ollama --stream`
- [x] Rate limit fallback: verify switch to nemotron when gemma-4 is 429'd
- [x] Missing API key: clear error message

Closes #26