### PR TITLE
feat(lnvo-v2): Stage 3 dialogue attribution stage (+ codex chunking)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,7 @@ skills-lock.json
 .omc/state/
 .omc/sessions/
 .omc/project-memory.json
+# Transient advisor (/ask) outputs — regenerated per run, never durable handoff.
+.omc/artifacts/
 
 .DS_Store

--- a/.omc/plans/lnvo-v2-dialogue-chunking-handoff.md
+++ b/.omc/plans/lnvo-v2-dialogue-chunking-handoff.md
@@ -1,0 +1,126 @@
+# Handoff: LNVO v2 dialogue chunking for oversized chapters
+
+> Self-contained brief for a **fresh session** (or post-compaction planner) to design
+> and implement chunking for the Stage 3 dialogue attribution. Everything below was
+> discovered in the session that fixed the timeout; read this first, then plan.
+
+## Why this work exists (the real problem)
+
+Stage 3 makes **one `codex` attribution call per chapter**. After raising the per-chapter
+timeout to 600s (see Baseline below), a real whole-volume run on
+`classroom-of-the-elite-year-2 / volume 4` produced `4 written, 5 skipped, 0 failed` —
+**no timeouts** — but exposed a *different, distinct* failure on the largest chapter:
+
+| Chapter | candidates | dialogues | rejected | narrator | outcome |
+| --- | --- | --- | --- | --- | --- |
+| chapter_07 | ~707 | 675 | 32 | None | ✅ usable |
+| **chapter_06** | **733** | **0** | **733 (all `model_omitted`)** | None | ❌ **degenerate** |
+
+chapter_06's model returned valid JSON **in time**, but with an empty decision set and this
+review note:
+
+> "Unable to return a complete strict attribution set within this response because the
+> payload contains several hundred candidate segments and requires one decision per
+> candidate segment."
+
+So this is an **output-completeness limit, NOT a timeout**. The model declines to emit
+~733 per-candidate decisions in a single response. Observed threshold: ~707 candidates OK,
+733 fails. The runner's trust boundary handled it safely (no corruption; flagged
+`needs_review`; every candidate → `model_omitted`), but the chapter has zero usable output.
+
+**Chunking is the fix:** split an oversized chapter into windows, attribute each in its own
+`codex` call, then merge the partial proposals before the existing assembly step.
+
+### Keep three distinct issues separate — do not conflate
+1. **Timeout** (wall-clock) — already fixed (configurable, default 600s).
+2. **Response completeness** (too many candidates per single response) — *this work*.
+3. **Narrator detection** — `narrator=None` on chapters 05/06/07 is the pre-existing
+   known issue #2 (`narrator_hint` is in the payload but `DIALOGUE_PROMPT` never tells the
+   model to use it). Independent of chunking, but chunking makes it worse (see below).
+
+## Baseline state (what's already in the tree)
+
+Branch `feat/lnvo-v2-dialogue-stage3`. The timeout fix is **implemented, codex-critic
+approved, 196 tests green, but UNCOMMITTED** — 8 modified files:
+`stages/dialogue/{agent.py,runner.py,__main__.py}`,
+`tests/.../dialogue/{test_agent,test_runner,test_main}.py`, `docs/lnvo/{03-dialogue,runbook}.md`.
+What it added: `agent.DEFAULT_DIALOGUE_TIMEOUT_SECONDS=600`; `timeout_seconds` on
+`DialogueConfig`/`DialogueVolumeConfig` + `--timeout` CLI flag; `run_codex_dialogue` raises
+both subprocess errors `from None` (so the prompt never leaks via `__cause__.cmd`).
+**Recommended first step of the new session: commit this baseline before starting chunking.**
+
+## Current architecture & the seams chunking plugs into
+
+Path: `automations/ln_voice_over_v2/stages/dialogue/`
+
+- `context.py::build_chapter_payload(segment_file, story_profile) -> ChapterPayload`
+  — `ChapterPayload` carries `segments` (EVERY segment, each tagged role `candidate`|`narration`),
+  `candidate_ids` (only `parser_hints.quote_candidate is True`), and `narrator_hint`.
+  `select_candidates()` is the candidate filter. **The payload deliberately includes narration
+  so the model has turn-taking context — any chunker MUST preserve narration context around
+  each candidate, i.e. split by segment windows, not by candidate id alone.**
+- `prompts.py::build_prompt(payload, roster) -> str` — wraps payload JSON + roster.
+- `agent.py::run_codex_dialogue(prompt, *, timeout_seconds=600) -> DialogueProposal`
+  — one codex subprocess; `DialogueProposal = {decisions[], narrator_raw, review_notes[]}`.
+- `runner.py::run_dialogue(config, *, attribute_fn=None)` — the orchestrator:
+  builds payload → `proposal = attribute_fn(payload)` → **assembles the trusted
+  `DialogueChapter`**: iterates `candidate_ids`, `decision_by_id` lookup, candidates the model
+  omitted become `RejectedCandidate(reason="model_omitted")`, canonicalizes speakers + narrator,
+  computes `review_required`, sorts by segment order, runs BOTH validators, writes.
+  The injectable seam is `attribute_fn: Callable[[ChapterPayload], DialogueProposal]`
+  (default closure calls `run_codex_dialogue(build_prompt(...), timeout_seconds=config.timeout_seconds)`).
+
+**Cleanest injection point:** keep the existing assembly untouched and insert a split→N-calls→merge
+layer that still returns ONE `DialogueProposal` to `run_dialogue`. I.e. a new
+`chunking.py` with pure, unit-testable `split_payload(payload, ...) -> list[ChapterPayload]`
+and `merge_proposals(list[DialogueProposal]) -> DialogueProposal`, wired so the default
+`attribute_fn` chunks when `len(candidate_ids)` exceeds a threshold and calls the model per chunk.
+This keeps the codex call behind the seam (tests inject a fake attribute/model and never spawn codex).
+
+## Design decisions the planner must resolve
+
+1. **When to chunk.** Recommend: only when `len(candidate_ids) > THRESHOLD` (e.g. ~250–400,
+   safely under the observed ~707 ceiling) — small/medium chapters keep the single-call path,
+   preserving whole-chapter narrator context for the common case.
+2. **How to split.** By segment windows that bound *candidate count per chunk* while carrying
+   the surrounding narration. Decide overlap: none (clean partition of candidates) vs small
+   overlap (better local context, but creates duplicate decisions — see #4).
+3. **Narrator merge.** Each chunk proposes its own `narrator_raw`. Pick a rule (first non-null /
+   majority vote). Whole-chapter narrator signal is weakened by chunking — strongly consider
+   fixing **known issue #2** (make `DIALOGUE_PROMPT` actually consume `narrator_hint`) and/or a
+   cheap dedicated narrator pass, so each chunk is seeded with the chapter narrator.
+4. **Duplicate decisions across chunks.** Today two decisions for one candidate silently
+   last-wins (**known issue #1**, `runner.decision_by_id`). Chunk overlap makes collisions
+   likely → the merge step should detect conflicts and flag them for review rather than
+   silently dropping. Consider fixing #1 as part of this.
+5. **review_notes** — concatenate + dedupe across chunks.
+6. **Where the code lives** — new `stages/dialogue/chunking.py`; keep `run_dialogue`’s assembly
+   as the single trust boundary that consumes the merged proposal.
+
+## Verification (acceptance)
+
+- **Real-data acceptance:** re-run chapter_06 (733 candidates) with `--force` and confirm it now
+  yields substantial real `dialogues` (not 733 `model_omitted`). Command:
+  `python -m automations.ln_voice_over_v2.stages.dialogue --series classroom-of-the-elite-year-2 --volume 4 --chapter chapter_06 --force`
+  (artifacts live at `~/.assistant/ln_voice_over_v2/projects/classroom-of-the-elite-year-2/4/dialogue/`).
+- **No regression:** chapter_07 (~707, currently works) must stay healthy.
+- **Unit tests (no codex):** `split_payload` (window boundaries, candidate-count caps, narration
+  retained) and `merge_proposals` (union of decisions, narrator merge rule, review_notes dedupe,
+  duplicate-conflict handling) are pure functions — test them deterministically. Keep the model
+  call behind the `attribute_fn` seam.
+- Gate: `ruff check` + `ruff format --check` + `pytest tests/automations/ln_voice_over_v2`.
+
+## Gotchas (carried over)
+
+- **codex `ruff --fix` PostToolUse hook strips a just-added import** when its first use lands in
+  a *later* edit. Add the import AND its first usage in the SAME edit, or re-add after.
+- Stage 3 is **non-deterministic**; idempotency = skip-existing + `--force`. The dialogue JSON is
+  the working review file; validate-before-write protects existing good files.
+- `codex exec` sometimes ends a turn narrating intent without applying patches — re-run/resume and
+  verify with `ruff` + `pytest` yourself.
+
+## Reference set to read first (new session)
+
+`docs/lnvo/03-dialogue.md` (contract + Implementation Notes + Debugging & Known Issues),
+`docs/lnvo/runbook.md` (Stage 3 commands), `.omc/plans/lnvo-v2-dialogue-stage3.md` (original
+consensus plan), and this file. Memory: `project_lnvo_dialogue_stage3_status`.

--- a/.omc/plans/lnvo-v2-dialogue-stage3.md
+++ b/.omc/plans/lnvo-v2-dialogue-stage3.md
@@ -1,0 +1,249 @@
+# LNVO v2 — Stage 3 `dialogue` Implementation Plan
+
+Status: **APPROVED FOR EXECUTION** (user 2026-05-30). Alias-resolution blocker resolved via **R1** — add additive `CharacterRegistry.resolve()` to `series/contracts.py` (sanctioned series-contract change). Implementation delegated to Codex agents, slices D0–D7.
+Mode: ralplan (consensus, short mode). Implementation delegated to Codex agents.
+Scope: `automations/ln_voice_over_v2/stages/dialogue/` + tests + docs. No `src/assistant/` changes.
+
+---
+
+## 1. Context & Current State
+
+The Stage 3 **contract layer already exists** and must NOT be rebuilt:
+
+- `stages/dialogue/contracts.py` — `DialogueChapter`, `Perspective`, `DialogueRow`, `RejectedCandidate` (strict, `extra="forbid"`, frozen).
+- `pipeline/validators.py::validate_dialogue_against_segments(dialogue, segments, registry)` — already enforces: chapter id match, every `segment_id` resolves, no duplicate dialogue segment, speaker canonical-or-`Unknown`, detected narrator canonical-or-`null`.
+- `docs/lnvo/03-dialogue.md` — the published contract page.
+- `common/paths.py::dialogue_chapter_path(...)` → `<volume>/dialogue/<chapter_id>.json`.
+- `series/contracts.py::CharacterRegistry` (`has_character(name)`), `Character(name, aliases, ...)`.
+- `common/enums.py` — `ReviewStatus{accepted, needs_review}`, `PerspectiveStatus{unset, detected}`, `ArtifactKind.DIALOGUE_CHAPTER`.
+
+**One sanctioned additive contract change (user-approved 2026-05-30):** add `CharacterRegistry.resolve(name) -> str | None` (exact name + alias lookup, no fuzzy) to `series/contracts.py`. This is additive (new method; no key/shape/enum change) and was explicitly confirmed per package `AGENTS.md:29`. No other contract change is permitted; any further gap must be raised, not silently made.
+
+The established **model-call boundary pattern** is `stages/prepare/ocr.py::run_codex_ocr`:
+`subprocess.run(["codex","exec","-i",img,"-m",model,"--ephemeral","--skip-git-repo-check","--ignore-user-config","-s","read-only",prompt])`, strict `model_validate_json` of stdout, `RuntimeError` on non-zero exit, `ContractValidationError` on malformed JSON. The prepare runner injects the boundary as an optional `ocr_fn` seam so tests never spawn `codex`. Stage 3 mirrors both the subprocess shape and the seam.
+
+What is **missing** (this plan):
+runner, CLI, LLM boundary (`agent.py` + `prompts.py`), context-window builder, name normalizer, `characters.json` loader (+ path helper), stage-local validation, and tests.
+
+---
+
+## 2. RALPLAN-DR Summary
+
+### Principles (load-bearing)
+1. **Deterministic contract around a replaceable model call.** Everything except the single model call is pure/testable; the model boundary is one injectable function returning strict JSON, validated before any write.
+2. **The model proposes; the runner decides.** The LLM never emits the persisted `DialogueChapter`. It returns an internal `DialogueProposal`; the runner canonicalizes names, computes status, and assembles the trusted artifact.
+3. **Never invent characters.** Unresolved speaker → `"Unknown"`; unresolved narrator → `null` + review flag. Canonical names/aliases come only from `characters.json`.
+4. **The dialogue JSON is the working review file.** Do not clobber human edits: skip if the file exists unless `--force`. Validate-before-write so a bad run never corrupts an existing good file.
+5. **Match Stage 1/2 conventions exactly.** Same runner/CLI/validation/test shapes; reuse existing helpers (`json_io`, `paths`, `resolve_story_profile_path`, the cross-validator).
+
+### Decision Drivers (top 3)
+- **Trust boundary integrity** — model output must be untrusted and fully validated.
+- **Reviewer safety** — re-runs must not destroy human review edits.
+- **Consistency & low surface area** — reuse existing contracts/validators/patterns; add only what each stage needs (package `AGENTS.md`).
+
+### Viable Options for the Main Decision (model invocation granularity)
+
+**Option A — One structured call per chapter (RECOMMENDED).**
+Pass the chapter's segments (candidates + surrounding narration as context) in one prompt; model returns one JSON: per-candidate accept/reject + speaker + reason, plus chapter narrator/perspective. Runner validates and assembles.
+- Pros: simplest deterministic contract around a single call; whole-chapter context is exactly what narrator/perspective resolution needs; one artifact, one validation; cheapest orchestration; mirrors "one strict JSON validated before writing."
+- Cons: one malformed response fails the whole chapter (acceptable — validate-before-write leaves prior file intact); very long chapters could strain context (mitigation: log candidate/segment counts; chunking is a documented follow-up, not v1).
+
+**Option B — One call per candidate + a separate perspective pass.**
+- Pros: per-item failure isolation; smaller prompts.
+- Cons: N+1 subprocess calls per chapter (slow, more failure surface); per-candidate calls lack whole-chapter view; narrator pass still needs chapter context anyway; more orchestration code. Heavier without clear v1 benefit.
+
+**Invalidation of B for v1:** light-novel chapters are short enough that the whole chapter fits one call; B's only real advantage (failure isolation) is already covered by validate-before-write + `--force` re-run. B is recorded as the scale-up path if real chapters exceed a single-call budget.
+
+### Acceptance Criteria (testable)
+- `python -m automations.ln_voice_over_v2.stages.dialogue --series S --volume V --chapter chapter_07_1` writes a `dialogue/chapter_07_1.json` that round-trips as `DialogueChapter` and passes both stage-local and cross validators.
+- Re-running without `--force` on an existing file does not overwrite it (exit 0, logged skip); `--force` regenerates.
+- A missing `characters.json` fails clearly before any model call.
+- `ruff format . && ruff check . && pytest tests/automations/ln_voice_over_v2/stages/dialogue` all green.
+- The nine spec test cases (Section 6) pass.
+
+---
+
+## 3. Target Module Layout
+
+```
+automations/ln_voice_over_v2/
+  common/paths.py                      # + characters_config_path(data_root, series)
+  stages/dialogue/
+    __init__.py                        # exists
+    contracts.py                       # exists — unchanged
+    config.py        (new)             # load_character_registry(); story_profile reuse
+    context.py       (new)             # candidate selection + context windows (pure)
+    names.py         (new)             # alias→canonical / Unknown / narrator resolution (pure)
+    prompts.py       (new)             # dialogue attribution prompt(s)
+    agent.py         (new)             # DialogueProposal model + run_codex_dialogue() boundary
+    validation.py    (new)             # stage-local artifact invariants
+    runner.py        (new)             # orchestration, injectable attribute_fn seam
+    __main__.py      (new)             # CLI, mirrors transform/__main__.py
+tests/automations/ln_voice_over_v2/stages/dialogue/
+    __init__.py, test_config.py, test_context.py, test_names.py,
+    test_agent.py, test_validation.py, test_runner.py
+docs/lnvo/03-dialogue.md               # add Implementation Notes + Design History
+```
+
+---
+
+## 4. Design Decisions
+
+### 4.1 Model boundary (`agent.py`)
+- Internal **`DialogueProposal`** strict Pydantic model (`extra="forbid"`), the ONLY thing the model emits:
+  ```
+  DialogueProposal:
+    decisions: tuple[CandidateDecision, ...]
+    narrator_raw: str | None
+    review_notes: tuple[str, ...] = ()
+  CandidateDecision:
+    segment_id: SegmentId
+    is_dialogue: bool
+    speaker_raw: str | None       # free-text name as the model sees it; "" / null allowed
+    reason: str = ""              # required-by-runner for rejects
+  ```
+- **`run_codex_dialogue(payload, *, model, executable="codex", timeout_seconds, prompt) -> DialogueProposal`** — subprocess shape copied from `run_codex_ocr` (`--ephemeral`, `--skip-git-repo-check`, `--ignore-user-config`, `-s read-only`), strict JSON parse, `RuntimeError` on non-zero exit, `ContractValidationError` on malformed.
+  **Payload delivery (D3 — was under-specified; resolved):** there is NO image, so the OCR `-i <image>` flag is **dropped entirely** (no dangling `-i`). The serialized chapter payload JSON is appended to the instruction prompt and passed as the final positional `prompt` argv element (same slot OCR uses for its prompt). The D3 "exact argv" test asserts this shape (no `-i`, payload-bearing final arg).
+- The runner accepts `attribute_fn: Callable[[ChapterPayload], DialogueProposal] | None` (the seam). Tests inject a fake; runtime builds the default from config.
+
+### 4.2 Context windows (`context.py`, pure)
+- `select_candidates(segment_file)` → candidates where `parser_hints.get("quote_candidate") is True`.
+- `build_chapter_payload(segment_file, story_profile_hints)` → a strict, serializable payload: ordered segments with `segment_id`, `text`, `quote_candidate`, and a `role` tag (`candidate`/`narration`), plus optional narrator hint from `story_profile.rules`. Window = each candidate plus its nearest preceding/following narration segments and nearby dialogue (configurable radius, default small). Never rewrites segment text.
+
+### 4.3 Name normalization (`names.py`, pure)
+> ⚠ **BLOCKER corrected from consensus (see §10.5).** v2 `CharacterRegistry` (`series/contracts.py:32-40`) exposes ONLY `has_character(name)` — exact `==` on `Character.name`, **no alias resolution and no fuzzy match**. v1's `find`/`fuzzy_find`/`_canonicalise_*` (`automations/ln_voice_over/models.py:131-190`, `review.py:160-162`) **do not exist in v2** and cannot be "ported." Alias→canonical (test cases 4, 6) therefore has no backing code today. Resolution mechanism is an **open decision for the user** (§10.5).
+- `canonical_speaker(raw, registry) -> str`: trimmed exact match to a `Character.name` → that name; match to any `Character.aliases` entry → that character's canonical name; empty/None/unmatched → `"Unknown"`. Never invents. **Exact name+alias only — NO fuzzy matching in v1** (v1's `fuzzy_find` + raw-passthrough are intentionally dropped; fuzzy is a follow-up).
+- `canonical_narrator(raw, registry) -> str | None`: same resolution; unresolved/None → `None`.
+- **First-person/POV rule:** a first-person speaker tag (`"I"`/`"me"`/equivalent) resolves through the *resolved chapter narrator* to that narrator's canonical name (the "POV character is the narrator" rule). Narration is not a dialogue row, so `"Narrator"` is NOT emitted as a speaker here.
+- `UNKNOWN_SPEAKER` is **imported from `pipeline/validators.py`** (single source) — do NOT redefine it in `names.py`.
+
+### 4.4 Runner assembly & review logic (`runner.py`)
+- Load `volume_index.json`; confirm `--chapter` is a member; resolve its `segments_file`; load the `SegmentFile`; load `CharacterRegistry` (required); resolve+load `story_profile` (optional, reuse `transform.chapters.resolve_story_profile_path`/`load_story_profile`).
+- If `dialogue/<chapter>.json` exists and not `--force`: log skip, return (protect the review file). With `--force`: regenerate.
+- Build payload → `attribute_fn(payload)` → `DialogueProposal`.
+- Assemble (rows built in **segment order**, not model output order, for clean diffs):
+  - **Stray ids** — a proposal `segment_id` NOT in the candidate set is rejected outright (model must not classify non-candidates): emit `RejectedCandidate(segment_id, reason="model_stray_segment")` only if it resolves to a real segment; otherwise drop it and add a `review_note`. (Cross-validator still guards segment existence.)
+  - **Omitted candidates** — a candidate the model returned NO decision for becomes an explicit `RejectedCandidate(segment_id, reason="model_omitted")` (NOT a silent soft-flag). This makes §4.5 coverage a real hard gate.
+  - accepted (`is_dialogue=True`) → `DialogueRow(segment_id, speaker=canonical_speaker(...))`; rejected → `RejectedCandidate(segment_id, reason)`. Narrator → `canonical_narrator(...)`; `perspective.status = detected` if narrator resolved else `unset` with `narrator=null`.
+- **`review_required`** (computed from the **canonicalized** speakers, not raw proposal) = any accepted speaker is `"Unknown"` OR perspective unresolved OR any candidate was omitted/stray OR model `review_notes` non-empty. **`status`** = `needs_review` if `review_required` else `accepted`. (An all-narration chapter with zero candidates is valid: `review_required=False`, `status=accepted`.)
+- `validate_dialogue_artifact(...)` (stage-local) AND `validate_dialogue_against_segments(...)` (cross) run BEFORE write (mirror transform: bad run leaves existing file untouched). Write via `save_json_contract`.
+
+### 4.5 Stage-local validation (`validation.py`) — only checks the cross-validator does NOT cover
+- **Coverage**: every candidate `segment_id` appears in exactly one of `dialogues` / `rejected_candidates` (no candidate silently dropped).
+- **Disjoint**: `dialogues` and `rejected_candidates` share no `segment_id`.
+- **Status consistency**: `status == needs_review` iff `review_required is True`.
+- (Segment-resolution, duplicate-dialogue, speaker/narrator canonicality are delegated to `validate_dialogue_against_segments`.)
+
+### 4.6 `characters.json` loading (`paths.py` + series-shared loader)
+- `paths.characters_config_path(data_root, series)` → `<data_root>/<series>/config/characters.json` (NEW; sits beside `story_profile.json`, in `common/paths.py` next to `dialogue_chapter_path`).
+- **Loader placement (consensus correction):** `load_character_registry(path) -> CharacterRegistry` is **series-shared, not dialogue-private** (Stage 4 scenes and Stage 5 generation also need the registry). Put it in a series-level module (e.g. `series/loader.py` or `common/series_config.py`) alongside `CharacterRegistry`, via `load_json_contract`. `dialogue/config.py` is a thin consumer that re-exports/calls it — no second copy in another stage later.
+- **No packaged fallback** (character lists are series content, not a default): a missing file raises a clear `ContractValidationError`/`FileNotFoundError` BEFORE any model call.
+
+### 4.7 CLI (`__main__.py`) — mirror `transform/__main__.py`
+`--series --volume --chapter [--data-root --force]`. Same logging setup, same `ContractValidationError`→exit 2 / generic→exit 1 / success→print path + exit 0. Batch-all-chapters is a documented follow-up.
+
+### 4.8 Non-determinism & copyright framing
+Stage 3 is NOT byte-deterministic (LLM). Idempotency is provided by skip-existing + validate-before-write, not reproducibility. The prompt frames attribution as a mechanical structured task and uses `--ignore-user-config` (same refusal mitigations as OCR); a single prompt for v1, with the prepare-style prompt-escalation list noted as a follow-up if refusals appear on real volumes.
+
+---
+
+## 5. Codex-Agent Slices (ordered; each = one bounded task)
+
+Each slice: **objective / allowed scope / inputs / output / verification (`ruff` + targeted `pytest`) / stop condition (tests green, in-scope files only).**
+
+- **D0 — Config seam.** `paths.characters_config_path` + `dialogue/config.py` (`load_character_registry`, story_profile reuse). Tests: load valid registry; missing file raises before any model call.
+- **D1 — Context windows.** `dialogue/context.py` (pure): candidate selection by `quote_candidate`, payload/window construction, no text rewrite. Tests: selection, window includes prev/next narration.
+- **D0b — Registry resolver (sanctioned contract change).** Add `CharacterRegistry.resolve(name) -> str | None` to `series/contracts.py` (exact name + alias, no fuzzy). Update `docs/lnvo/00-series-parameters.md`/contracts-index if it documents the registry. Tests: name match; alias match; miss→`None`. Must land before D2.
+- **D2 — Name normalization.** `dialogue/names.py` (pure), thin wrapper over `CharacterRegistry.resolve` (D0b). Exact name+alias only, no fuzzy. Tests: alias→canonical; unknown→`Unknown`; first-person→narrator's canonical name; narrator unresolved→`None`.
+- **D3 — Model boundary.** `dialogue/prompts.py` + `dialogue/agent.py` (`DialogueProposal`, `run_codex_dialogue`). Tests (monkeypatch `subprocess.run`, mirror `test_ocr_function.py`): exact argv; strict stdout parse; malformed→`ContractValidationError`; non-zero exit→`RuntimeError`.
+- **D4 — Stage-local validation.** `dialogue/validation.py` (coverage, disjoint, status consistency). Tests for each invariant.
+- **D5 — Runner.** `dialogue/runner.py` with injectable `attribute_fn`. Tests (fake seam): valid file; rejected candidate; unknown speaker; alias normalization; invalid segment reference raises; unresolved narrator → `review_required`/`needs_review`; skip-existing vs `--force`.
+- **D6 — CLI.** `dialogue/__main__.py`. Light test: arg parse + exit codes via injected seam or `ContractValidationError` path.
+- **D7 — Docs.** `docs/lnvo/03-dialogue.md` Implementation Notes (model boundary, skip-existing, status rule, characters.json required) + Design History entry. Touch `runbook.md`/`README` only if a user-facing command line changes; CONTEXT.md only if vocabulary changes (not expected).
+
+Dependency order: D0,D1,D2 parallel-safe → D3 → D4 → D5 → D6 → D7. Commit per slice after `ruff` + `pytest` green (project `AGENTS.md` commit discipline; automations need no GitHub issue).
+
+---
+
+## 6. Test Matrix (the nine required cases → slice)
+1. valid dialogue file → D5
+2. rejected quote candidate → D5
+3. unknown speaker → D2 + D5
+4. alias normalization → D2 + D5
+5. invalid segment reference → D5 (cross-validator raises)
+6. unresolved narrator marks review needed → D2 + D5
+7. (added) missing `characters.json` errors before model call → D0
+8. (added) skip-existing protects review file; `--force` regenerates → D5
+9. (added) candidate coverage / disjoint / status-consistency invariants → D4
+10. (added) unknown `--chapter` fails before any model call → D5/D6
+11. (added) `review_required` computed from canonicalized speakers (not raw proposal) → D5
+12. (added) omitted candidate → explicit `RejectedCandidate(reason="model_omitted")` → D5
+
+---
+
+## 7. Risks & Mitigations
+- **Clobbering human review edits** → skip-existing-unless-`--force`; validate-before-write.
+- **Model invents a character / mislabels** → canonicalize to `Unknown`/`null` + `review_required`; reviewer fixes the working file.
+- **Malformed model JSON** → strict parse → `ContractValidationError`; existing file untouched.
+- **Codex refusal on copyrighted excerpts** → mechanical framing + `--ignore-user-config`; escalation-prompt list is a ready follow-up.
+- **Large chapters strain a single call** → log counts; Option B / chunking documented as scale-up.
+- **Scope creep into contracts** → contracts frozen; any gap is raised for user confirmation, not silently changed.
+
+## 8. Out of Scope
+Narration adaptation (Stage 4), voice mapping/generation (Stage 5), batch-all-chapters CLI, response caching, multi-volume sampling, any `src/assistant/` change.
+
+---
+
+## 9. ADR (to finalize after consensus)
+- **Decision:** _pending_ (recommend Option A — one structured per-chapter call).
+- **Drivers:** trust-boundary integrity, reviewer safety, consistency/low surface area.
+- **Alternatives considered:** Option B (per-candidate) — deferred as scale-up.
+- **Consequences:** non-deterministic stage; idempotency via skip-existing; new `characters.json` hard dependency.
+- **Follow-ups:** batch-all CLI; prompt escalation; chunking for large chapters.
+
+---
+
+## 10. Consensus Review
+
+> Process note: one Opus Architect pass and two Sonnet Critic passes ran as separate read-only agents against this plan and the real codebase and returned in full (earlier launches that appeared to stall did complete). Their findings are summarized below; the inline analytical lanes are retained as the synthesis. The refinements in §10.3 + §10.6 are **authoritative addenda** and override anything earlier in this plan that conflicts. The blocker in §10.5 is an **open decision the user must make** before D2 implementation (it concerns a frozen series contract).
+
+### 10.1 Architect lane — steelman antithesis + synthesis
+**Antithesis (strongest case against the central design):** A single per-chapter call couples two distinct tasks — per-candidate accept/reject/attribute and whole-chapter narrator/perspective resolution — so one malformed or partial response fails the entire chapter and discards all correct per-candidate work. Attribution quality also degrades as candidate count grows (attention dilution), exactly where it is hardest. The internal `DialogueProposal` layer can look like throwaway ceremony versus having the model emit `DialogueRow`-shaped rows directly and letting the existing cross-validator reject bad names.
+
+**Rebuttal / synthesis:** `DialogueProposal` is **the trust boundary, not ceremony**. If the model emitted `DialogueChapter` directly it could set `series`/`volume`/`schema_version`/`artifact_kind`/`status`/`review_required` and emit invented-but-canonical-looking attributions. `validate_dialogue_against_segments` only catches *non-canonical* names — it cannot catch an invented-but-canonical speaker, nor verify status/review_required/perspective integrity. The proposal→assemble split is correct. Failure-isolation is real but mitigated by validate-before-write + cheap `--force` re-run (prior file untouched). For v1 light-novel chapter sizes, **Option A stands**. **Architect verdict: APPROVE WITH MINOR CHANGES** (see §10.3).
+
+### 10.2 Critic lane
+Principle–option consistency: ✓. Fair alternatives: ✓ (add option C below). Testable acceptance criteria: ✓ (tighten assertions, §10.3 #5). Concrete verification (`ruff` + per-slice `pytest`): ✓. Risks coverage: ✓. **Critic verdict: APPROVE after folding in the §10.3 refinements.**
+
+### 10.3 Refinements folded in (authoritative)
+1. **First-person/POV resolution** — `names.py`/slice D2 must implement: a first-person speaker tag ("I"/"me"/equivalent) resolves through the *resolved chapter narrator* to that narrator's canonical name (per v1 `review._canonicalise_*` and the "POV character is the narrator" rule). Narration speaker label is `"Narrator"`.
+2. **Prompt includes the character roster** — `prompts.py`/D3 must inject the registry's canonical names + aliases to anchor attribution and suppress invented names. Keep `speaker_raw` free-text (the model still needs to express pronoun / "previous speaker" cases) and canonicalize defensively in the runner.
+3. **Deterministic row ordering** — the runner assembles `dialogues` and `rejected_candidates` sorted by segment order (not model output order) so the working review file diffs cleanly across re-runs.
+4. **Alternative C recorded & rejected** — "model emits `DialogueChapter` directly": rejected because it removes the trust boundary (cannot validate invented-but-canonical names, status/review_required, or perspective integrity).
+5. **Tighter acceptance assertions** — (a) invalid segment reference ⇒ `ContractValidationError` raised AND no dialogue file written; (b) skip-existing ⇒ existing file content preserved (assert bytes unchanged).
+6. **Candidate-count observability** — `context.py`/runner logs candidate & segment counts and emits a soft `WARNING` above a threshold to signal "Option-B / chunking territory". Confirmed: `characters_config_path` lives in `common/paths.py` beside `dialogue_chapter_path`; loader `load_character_registry` lives in `dialogue/config.py`.
+
+### 10.4 Finalized ADR (supersedes §9)
+- **Decision:** Option A — one structured per-chapter Codex call returning an internal `DialogueProposal`; the runner canonicalizes names, computes review state, then assembles and validates the trusted `DialogueChapter` (stage-local + cross validators) before writing; skip-existing unless `--force`.
+- **Drivers:** trust-boundary integrity; reviewer safety (the dialogue JSON is the working review file); consistency / low surface area; whole-chapter context for narrator resolution.
+- **Alternatives considered:** B (per-candidate calls + separate perspective pass) — deferred as the scale-up path for oversized chapters; C (model emits `DialogueChapter` directly) — rejected, no trust boundary.
+- **Why chosen:** simplest deterministic contract around a single replaceable model call; reuses the proven `run_codex_ocr` boundary shape and injectable-seam test pattern; honors the user's stated recommendation.
+- **Consequences:** the stage is non-deterministic (no byte-reproducibility); idempotency comes from skip-existing + validate-before-write; a new hard dependency on `characters.json`; a malformed response fails a whole chapter (acceptable — re-run is cheap and the prior file is intact).
+- **Follow-ups:** batch-all-chapters CLI; prompt-escalation list for refusals; chunking / Option B for oversized chapters; optional model-response caching.
+
+### 10.5 ✅ RESOLVED — alias resolution lives on the registry (R1, user-approved 2026-05-30)
+v2 `CharacterRegistry` (`series/contracts.py:32-40`) had only `has_character(name)` (exact name match), and the cross-validator accepts a speaker only if `has_character(speaker)` is true (`validators.py:317-321`) — so alias→canonical resolution (Principle 3, test cases 4 & 6) had no backing code. **Decision: R1.** Add additive `CharacterRegistry.resolve(name) -> str | None` (exact name + alias match, **no fuzzy**) to `series/contracts.py` as a new slice **D0b** before D2; `names.py` becomes a thin wrapper over it; Stage 4/5 reuse it. v1's `fuzzy_find` + raw-passthrough remain deliberately dropped (fuzzy = follow-up).
+
+### 10.6 Additional refinements folded in (from the returned agents; authoritative)
+7. **Omitted candidates → explicit `RejectedCandidate(reason="model_omitted")`** and stray ids → `reason="model_stray_segment"`, so §4.5 coverage is a hard gate, not a soft flag (resolves the §4.4/§4.5 double-rule). Folded into §4.4.
+8. **D3 payload delivery resolved** — no `-i` image flag; payload JSON appended to the final positional `prompt` argv element; the "exact argv" test asserts no dangling `-i`. Folded into §4.1.
+9. **`load_character_registry` is series-shared**, not `dialogue/config.py`-private (scenes/generation reuse). Folded into §4.6.
+10. **Two added tests:** (a) unknown `--chapter` fails clearly BEFORE any model call (new `--chapter` membership logic is untested ground in transform); (b) `review_required` is computed from *canonicalized* speakers, not the raw proposal. Added to §6 as cases 10–11.
+11. **CLI safety doc:** `--force` destroys a human-edited chapter file; the deferred batch-all CLI must NOT default to `--force` (a `--only-missing` mode is the safe batch pattern). Folded into §4.7 follow-ups.
+
+### 10.7 Verdicts
+- **Opus Architect:** REQUEST CHANGES → resolved by §10.5 decision + §10.6 items 7–9; core architecture (deterministic runner, injectable seam, proposal↔artifact split, Option A, validate-before-write, skip-existing) APPROVED unchanged.
+- **Critic A:** APPROVE after folding §10.3/§10.6 refinements.
+- **Critic B (CONDITIONAL APPROVE):** three slice-spec clarifications (D3 argv, loader placement, omitted-candidate rule) — all folded in (§10.6 items 7–9).
+
+**Consensus status: APPROVED contingent on the §10.5 user decision. Plan = PENDING USER APPROVAL. No execution performed.**

--- a/.omc/plans/lnvo-v2-transform-stage2.architect.md
+++ b/.omc/plans/lnvo-v2-transform-stage2.architect.md
@@ -1,0 +1,45 @@
+# Architect Review — LNVO v2 Stage 2 (`transform`) Plan
+
+Reviewer: `oh-my-claudecode:architect` (Claude opus)
+Target: `/Users/regiswoof/_workspace/projects/assistant/.omc/plans/lnvo-v2-transform-stage2.md`
+
+## Verdict
+`ITERATE`
+
+## Steelman Antithesis
+Strongest opposing position to **Segmentation option X + cross-page narration merging**: Stage 2 should emit page-stable segments — one narration segment per page boundary at most, never merged across pages. Under the current draft, re-running `prepare` for a single bad page (a `needs_review` retry, a fixed OCR transcript, an inserted page) can change which `text_unit_id`s belong to which segment, shifting every downstream `segment_id` whose narration straddles that page. That breaks Decision Driver #2 ("Stable IDs across reruns"). Per-page narration segments would sacrifice a small amount of narrative cohesion (Stage 3/4 has to re-join them) in exchange for monotonic stability of `seg_NNNNNN` under partial re-OCR, far simpler `source_unit_ids` (always length 1 for narration), and a cleaner round-trip invariant. The user's directive ("narration between quotes stays grouped as much as reasonably possible") admits this reading — "between quotes" can be interpreted as *within the page-local quote envelope*.
+
+Parallel antithesis on **Chapter Detection B**: inline default regex (Q8 default) creates a hidden cross-cutting concern. Prefer profile-rule-as-only-source, with the default living in `series/contracts.py` as a `StoryProfile` default factory, so the regex is discoverable by series authors and isn't buried in `stages/transform/chapters.py`.
+
+## Real Tradeoff Tensions
+
+- **T1 — ID stability vs. narrative cohesion.** The plan optimizes for cohesion (cross-page narration merging) at the cost of segment-id stability under prepare reruns. The plan must commit to page-stable narration *or* spell out the contract that `seg_NNNNNN` is only stable for a given `prepared/volume.json` byte content.
+- **T2 — Determinism (Q6 hard-fail coverage) vs. resilience on messy first runs.** Q6 defaults to hard-raise while Q3 defaults to silently skipping `needs_review` pages. If a `needs_review` page sits between two quote-bearing pages, union-coverage either exempts the unit silently or refuses to run. Both defaults can't be right simultaneously.
+- **T3 — Heading mid-page assignment vs. content preservation.** Boundary Rule §4 says a mid-page heading starts a new chapter and the *whole* page becomes the new chapter's prefix. Pre-heading prose silently migrates to a later chapter — a provenance-principle smell. Safer rule: split the page at the heading line, attach pre-heading slice to prior chapter's last segment, post-heading to the new chapter.
+
+## Architectural Issues to Resolve
+
+1. **Mid-page heading rule** (Chapter Detection §4) — must split the page text, not reassign the whole page. Otherwise pre-heading prose migrates silently.
+2. **Cross-validator placement / call site** — placement in `pipeline/validators.py` is correct; missing: must state it is called inside `run_transform` (mirroring `validate_prepared_volume` in `run_prepare`).
+3. **`runner.py` shape drift** — confirm no `Callable` seam kwargs (no external CLI/network). `--force` semantics mirror prepare's `shutil.rmtree`.
+4. **`validation.py` split** — be explicit: stage-local validation = artifact-internal invariants; `pipeline/validators.py` cross-validator = round-trip against `prepared/volume.json`.
+5. **Stage-3 creep risk in quote heuristics** — call out that single-quote paragraph-start rule is the structural-only line; em-dash dialogue (Q5) and sentence splitting belong to Stage 3+.
+6. **Doc-update list is incomplete** — add `automations/ln_voice_over_v2/AGENTS.md` (B1 widening), `automations/ln_voice_over_v2/README.md` (CLI usage), and re-confirm `seg_NNNNNN` 1-indexed in `docs/lnvo/contracts-index.md`.
+7. **Q1/Q7 must be promoted from "Blocker" to "Decided"** — `unit_NNNNNN` is 0-indexed (per `stages/prepare/text_units.py:34`); `seg_NNNNNN` is 1-indexed. Lock both in the ADR.
+8. **`__init__.py` missing from explicit module list** — mirror prepare exactly.
+
+## Synthesis
+Single most-valuable change: introduce a **"Stability Contract" subsection** that resolves T1 + T3 together. Keep cross-page narration merging *but* require that the cross-validator (Q6 hard-raise) treat a `needs_review` page as a hard gate: if any `text_unit` in the chapter is `needs_review`, transform refuses to merge narration across that gap and instead emits page-local narration segments for the affected window with `parser_hints.needs_review_boundary: true`. Pair with the mid-page heading split fix.
+
+## Principle Violations
+- **Stable IDs (Driver #2):** cross-page narration merging weakens reproducibility under partial prepare reruns — medium severity, undocumented.
+- **Provenance mandatory:** mid-page heading rule risks silent migration of pre-heading prose — medium severity.
+- Determinism, structural-hints-only, contracts-authoritative, no-artifact-sprawl: clean.
+
+## Key References
+- `.omc/plans/lnvo-v2-transform-stage2.md` §"Chapter Detection Strategy" §4 — mid-page rule
+- `.omc/plans/lnvo-v2-transform-stage2.md` §"Segment Creation Strategy" §4 — cross-page narration merging
+- `automations/ln_voice_over_v2/stages/prepare/runner.py:140` — pattern: cross-validator called inside `run_prepare`
+- `automations/ln_voice_over_v2/stages/prepare/text_units.py:34` — 0-indexed `unit_NNNNNN` source of truth
+- `automations/ln_voice_over_v2/pipeline/validators.py:16` — mirror target for `validate_transform_against_prepared`
+- `automations/ln_voice_over_v2/AGENTS.md:25` — runner/CLI restriction widening required by B1

--- a/.omc/plans/lnvo-v2-transform-stage2.architect.v3.md
+++ b/.omc/plans/lnvo-v2-transform-stage2.architect.v3.md
@@ -1,0 +1,41 @@
+# Architect Review v3 — LNVO v2 Stage 2 (`transform`) Plan
+
+Reviewer: `oh-my-claudecode:architect` (Claude opus)
+Iteration: 2 (post v1 ITERATE)
+Target: `/Users/regiswoof/_workspace/projects/assistant/.omc/plans/lnvo-v2-transform-stage2.md` (v3)
+
+## Verdict
+`APPROVE`
+
+## How v1 Findings Resolved in v3
+1. **Mid-page heading rule** — RESOLVED. "Chapter Detection Strategy" §4 splits the page at the heading line; same `text_unit_id` appears in both neighbours' `source_unit_ids`.
+2. **Cross-validator call site** — RESOLVED. Validator runs inside `run_transform` before any write, mirroring `prepare/runner.py:140-141`.
+3. **Runner shape drift / no Callable seam** — RESOLVED. "Runner + CLI Shape" forbids `Callable` seam kwargs, network, subprocess; `--force` mirrors prepare's `shutil.rmtree`.
+4. **`validation.py` split** — RESOLVED. Stage-local (artifact-internal) vs `pipeline/validators.py` (round-trip) are separate subsections.
+5. **Stage-3 creep risk** — RESOLVED. Single-quote-opener heuristic tagged as "structural-only line"; em-dash explicitly deferred.
+6. **Doc-update list completeness** — RESOLVED. All docs + template + AGENTS.md listed.
+7. **Q1/Q7 promotion** — RESOLVED. Locked in "Outputs" + ADR "Locked decisions".
+8. **`__init__.py` in module list** — RESOLVED. Listed under "Scope".
+9. **Q3↔Q6 conflict** — RESOLVED via `needs_review` placeholder segment.
+10. **Ruff+pytest verification** — RESOLVED.
+
+## New v3 Risks
+1. **`display_name` required contract addition.** Existing `_volume_index()` fixture at `test_contracts.py:241` will break the instant T4 lands. Plan bundles the fixture update inside T4 — safe if Codex actually includes that line.
+2. **Template-vs-override resolution is input #2 to ID stability.** Editing the per-series override renumbers `segment_id`s. Operational risk only; plan flags it in Stability Contract consequences.
+3. **Disambiguation Protocol is a project-wide rule introduced in a stage plan.** Minor scope-creep concern; AGENTS.md is the right home.
+
+## Slice Ordering Audit
+- **T0 (done):** docs + template + AGENTS.md only. Clean.
+- **T1–T3:** pure-function modules with their own tests. They emit `display_name` as a Python string internally, NOT as a Pydantic field — `ChapterIndexEntry` is not yet modified. Safe **provided** T1–T3 tests do not transitively instantiate `ChapterIndexEntry`.
+- **T4 (contract + validators):** lands `display_name` on `ChapterIndexEntry` AND updates `_volume_index()` fixture. Only slice where repo-wide tests would fail without that bundle. Safe.
+- **T5 (runner + CLI + e2e):** depends on T1–T4. Correctly placed last among code slices.
+- **T6 (README + contracts-index):** docs polish.
+
+## Final Note
+Green light for Codex Critic. v3 cleanly resolves every v1 finding, locked user decisions are reflected in body and ADR, slice ordering keeps each intermediate commit green provided T4 bundles the fixture update. Critic should sanity-check that T1–T3 tests do not transitively instantiate `ChapterIndexEntry`.
+
+## Key References
+- `.omc/plans/lnvo-v2-transform-stage2.md` — v3 plan
+- `automations/ln_voice_over_v2/stages/transform/contracts.py` — `ChapterIndexEntry` lacks `display_name` (T4 target)
+- `automations/ln_voice_over_v2/stages/prepare/runner.py:140-141` — validator-before-save pattern T5 mirrors
+- `tests/automations/ln_voice_over_v2/test_contracts.py:241` — `_volume_index()` fixture T4 must update

--- a/.omc/plans/lnvo-v2-transform-stage2.critic.md
+++ b/.omc/plans/lnvo-v2-transform-stage2.critic.md
@@ -1,0 +1,35 @@
+# Critic Review — LNVO v2 Stage 2 (`transform`) Plan
+
+Reviewer: Codex CLI (`gpt-5.5`, read-only, xhigh reasoning)
+Target: `/Users/regiswoof/_workspace/projects/assistant/.omc/plans/lnvo-v2-transform-stage2.md`
+Architect input also visible: `.omc/plans/lnvo-v2-transform-stage2.architect.md`
+
+## Verdict
+`ITERATE`
+
+## Strengths
+- Cleanly honors the Stage 2 boundary: deterministic transform only, no LLM/OCR/dialogue/scene ownership.
+- Correctly uses `parser_hints.quote_candidate` without adding public `Segment` fields; `parser_hints` is already `dict[str, Any]` in `stages/transform/contracts.py:37`.
+- Options B and X match the user direction better than hardcoded/manual chaptering or sentence/paragraph segmentation.
+- Validator intent is strong: ID density, path shape, chapter/file agreement, and `source_unit_ids` coverage are all named.
+
+## Findings (must-fix)
+1. **Chapter Detection Strategy.** The mid-page heading rule is wrong. It assigns the entire page to the new chapter and makes pre-heading prose "a narration prefix of the new chapter" (`.omc/plans/lnvo-v2-transform-stage2.md:81`), which violates provenance and chapter semantics. Fix by splitting page text at the heading: pre-heading text stays with the prior chapter, heading/post-heading text starts the new chapter; update `test_chapters.py` accordingly.
+2. **Segment Creation Strategy / Blockers Q3+Q6.** The plan conflicts with itself on `needs_review`: skip empty/`needs_review` units (line 91, Q3 default line 247) while claiming hard coverage (line 147, Q6 default line 250). Prepare explicitly emits empty sentinel transcripts with `needs_review: true` (`docs/lnvo/01-prepare.md:70-72`). Fix by deciding one behavior before implementation — preferably hard-fail transform on any `needs_review` unit or emit an explicit non-empty placeholder segment.
+3. **Validation / Runner + CLI Shape.** The cross-validator is planned but not required in `run_transform`. Adding `validate_transform_against_prepared` (lines 154–155) is insufficient unless the runner calls it before writes, mirroring prepare's validate-before-save pattern (`stages/prepare/runner.py:140-141`). Fix the runner spec and tests to require that call.
+4. **Tests / Verification command.** `pytest tests/automations/ln_voice_over_v2/` alone (lines 211–214) is not sufficient completion evidence. Project rules require Ruff formatting/linting plus pytest. Fix verification to include `ruff format --check .`, `ruff check .`, and the pytest command.
+
+## Findings (should-improve)
+1. **RALPLAN-DR Summary.** Option Y is partly straw-manned: sentence segmentation does not "push work onto Stages 3/4" as stated (line 39); the real rejection is that it over-fragments Stage 2 and violates quote-boundary grouping. Fix the rationale.
+2. **Doc Updates.** The plan says no `contracts-index` changes (line 224), but the index still shows segment shape as `seg_000000` (`docs/lnvo/contracts-index.md:22`) while the plan requires 1-indexed `seg_000001` starts. Clarify whether the index is only a regex example or update it.
+3. **Runner + CLI Shape.** Option B depends on `StoryProfile.rules.chapter_headings`, but the runner does not specify how `<series>/config/story_profile.json` is loaded, despite being a Stage 2 input (`docs/lnvo/02-transform.md:14-17`). Add the load path and accepted rule shape.
+
+## Acceptance Criteria Audit
+- `test_chapters.py`: Needs sharpening; must assert split-at-heading behavior, not whole-page reassignment.
+- `test_quotes.py`: Mostly testable, but page-boundary `source_unit_ids` belongs in segmentation, not tokenizer-only tests.
+- `test_segments.py`: Needs sharpening; assert exact text, exact `source_unit_ids`, and exact `parser_hints`.
+- `test_runner.py`: Needs sharpening; require validator invocation before write and exact emitted paths/files.
+- `test_validators.py`: Testable as written, but add duplicate/gapped `order` and bad `segments_file` path cases.
+
+## Final Recommendation
+Minimum delta to approve: fix the mid-page split rule, resolve `needs_review` behavior, require `run_transform` to call the new cross-validator, sharpen the five test specs, and expand verification to Ruff plus pytest. I agree with the Architect on the mid-page and validator-call issues; the added blocker here is that the current test plan would let those defects slip through.

--- a/.omc/plans/lnvo-v2-transform-stage2.critic.v3.md
+++ b/.omc/plans/lnvo-v2-transform-stage2.critic.v3.md
@@ -1,0 +1,38 @@
+# Critic Review v3 — LNVO v2 Stage 2 (`transform`) Plan
+
+Reviewer: Codex CLI (`gpt-5.5`, read-only, xhigh reasoning)
+Iteration: 2 (post v1 ITERATE)
+Target: `/Users/regiswoof/_workspace/projects/assistant/.omc/plans/lnvo-v2-transform-stage2.md` (v3)
+Architect v3 verdict: `APPROVE`
+
+## Verdict
+`ITERATE` (two tightly-scoped slice-ordering polishes — Codex states: "After that, the plan is approve-ready.")
+
+## v1 Must-Fix Items: Closed
+- **Mid-page heading split** — RESOLVED. "Chapter Detection Strategy" §4 (plan lines 129–133).
+- **`needs_review` resolution** — RESOLVED. Deterministic placeholder + hard boundaries in "Segment Creation Strategy" §2 (lines 147–151), test coverage at lines 279–282.
+- **Cross-validator inside `run_transform` before write** — RESOLVED. Runner sequence at lines 231–234.
+- **Ruff + pytest verification** — RESOLVED. Lines 302–308.
+
+## New Findings (v3 only)
+1. **T4 file list omits `tests/automations/ln_voice_over_v2/test_contracts.py`.** Plan notes the `_volume_index()` fixture needs `display_name="Chapter 1"` at lines 252–255, but the Slice T4 entry at line 353 doesn't list the test file. Risk: T4 commits a required-field contract change without the fixture migration, breaking the repo-wide test suite mid-stack.
+2. **T1 slice-order ambiguity.** `test_chapters.py` description (lines 262–268) talks about "three `ChapterIndexEntry`s with `display_name`s" — safe only if T1 uses an internal chapter-split dataclass, not `stages/transform/contracts.py::ChapterIndexEntry`, since the latter doesn't yet have `display_name` until T4 lands.
+
+## Slice Ordering Verdict
+- T0 — Green; docs/template/AGENTS only (ruff format/check passed).
+- T1 — Not proven green; T1 tests must use an internal chapter-split type, not `ChapterIndexEntry`.
+- T2 — Green; tokenizer-only.
+- T3 — Green if it stays on internal split/segment-building structures.
+- T4 — Unsafe as written; must explicitly bundle `tests/.../test_contracts.py:241` `_volume_index()` fixture update.
+- T5 — Green after T4 only; runner tests correctly depend on `VolumeIndex` with `display_name`.
+- T6 — Green; docs only.
+
+## Acceptance Criteria Audit (delta from v1)
+- `test_chapters.py` — improved, but regressed on slice ordering until clarified.
+- `test_quotes.py` — still good.
+- `test_segments.py` — improved.
+- `test_runner.py` — improved.
+- `test_validators.py` — improved.
+
+## Final Recommendation
+Not ready to start T1. Make one plan amendment first: clarify T1 tests use internal chapter-split objects (not `ChapterIndexEntry`), and update Slice T4 to explicitly include `tests/automations/ln_voice_over_v2/test_contracts.py::_volume_index()` with `display_name="Chapter 1"`. After that, the plan is approve-ready.

--- a/.omc/plans/lnvo-v2-transform-stage2.md
+++ b/.omc/plans/lnvo-v2-transform-stage2.md
@@ -1,0 +1,424 @@
+# LNVO v2 — Stage 2 (`transform`) Implementation Plan
+
+Status: **pending approval** (v3 draft, no code written yet)
+
+Revision history:
+- v1 — initial draft.
+- v2 — addressed Architect + Critic v1 findings (mid-page split, `needs_review` resolution, validator-call-in-runner, ruff+pytest verification, Stability Contract, Q1/Q7 promoted to decided).
+- v3 — locks user decisions: drops the stage-contract-only restriction in package AGENTS.md; adds `ChapterIndexEntry.display_name`; keeps quote glyphs; defers em-dash dialogue; moves heading-regex defaults to a packaged series template + per-series `<data_root>/<series>/config/story_profile.json`; adds Disambiguation Protocol (Codex agents read volume text when content is ambiguous).
+- v3.1 — slice-ordering polish: introduced an internal `ChapterSplit` dataclass to keep T1 green before the contract change landed. **Superseded by v3.2.**
+- v3.2 — over-engineering fix (user-driven): the v3.1 `ChapterSplit` shim existed only because the contract change (`ChapterIndexEntry.display_name`) was scheduled at slice 4. Moving the contract change to slice 1 eliminates the shim entirely. New order: T1 = contract migration, T2 = chapters, T3 = quotes, T4 = segments, T5 = validators, T6 = runner, T7 = docs polish. The chapter detector now returns `ChapterIndexEntry` directly; the only remaining private intermediate is a per-unit text-slice helper that bookkeeps partial-page contributions during mid-page splits (genuinely an internal detail, not a contract shim).
+
+Authoritative references:
+- `docs/lnvo/02-transform.md` (Volume Index + Segment File contracts).
+- `docs/lnvo/01-prepare.md` (PreparedVolume input).
+- `docs/lnvo/00-series-parameters.md` (Story profile shape and `<series>/config/` layout).
+- `docs/lnvo/contracts-index.md` (id and path rules).
+- `automations/ln_voice_over_v2/stages/transform/contracts.py` (Pydantic models already in place; will gain `display_name`).
+- `automations/ln_voice_over_v2/series/contracts.py` (`StoryProfile` already has free-form `rules: dict[str, Any]`).
+- `automations/ln_voice_over_v2/AGENTS.md` (stage-boundary rules — will be rewritten by this slice; see "Doc Updates").
+- `automations/ln_voice_over_v2/stages/prepare/{runner,text_units,validation}.py` (the slice this plan mirrors).
+- Root `AGENTS.md` lines 37–65 (Ruff + pytest verification rules).
+
+---
+
+## RALPLAN-DR Summary
+
+### Principles
+1. **Deterministic, code-driven only.** No LLM, OCR, attribution, scene detection, or audio/visual generation in Stage 2.
+2. **Contracts are authoritative.** The Pydantic models in `stages/transform/contracts.py` and the doc page in `docs/lnvo/02-transform.md` must agree; nothing else may be invented.
+3. **Stage 2 produces structural hints, not semantics.** Use `parser_hints.quote_candidate: bool`; never a final `segment_type`.
+4. **Provenance is mandatory.** Every segment cites the contributing `text_unit_id`s in `source_unit_ids`. Heading text is never silently relocated and is always preserved in segment `text`.
+5. **No artifact sprawl.** Segment text lives in JSON; do not emit chapter `.txt` files.
+6. **No volume content guessing.** When implementation depends on what is actually in a volume's text (heading style, dialogue convention, glyph set), spawn Codex agent(s) to read the real text. See "Disambiguation Protocol" in Doc Updates.
+
+### Decision Drivers
+1. **Stage boundary discipline** — `transform` owns chapter splitting + quote-aware segmentation only; dialogue/narration/scene reasoning belongs to Stages 3/4.
+2. **Stable IDs across reruns** — `chapter_id`/`segment_id` are deterministic functions of `prepared/volume.json` byte content + the loaded `story_profile.json` byte content. See "Stability Contract" below.
+3. **Page-provenance round trip** — concatenating each chapter's segment `text` (in order) must cover every non-empty `text_unit` referenced by `source_unit_ids`.
+
+### Viable Options (recap)
+
+- **Chapter detection** → **(B) profile-driven regex** with a packaged default template at `automations/ln_voice_over_v2/series/templates/story_profile.default.json`. (A) and (C) invalidated as default.
+- **Segmentation** → **(X) quote-boundary segmentation**, paired with the Stability Contract. (Y) and (Z) invalidated.
+
+---
+
+## Stability Contract
+
+`chapter_id` and `segment_id` are deterministic functions of:
+1. The byte content of `<volume>/prepared/volume.json`.
+2. The byte content of the active `story_profile.json` (either `<data_root>/<series>/config/story_profile.json` when present, or the packaged template `automations/ln_voice_over_v2/series/templates/story_profile.default.json` when absent).
+
+Consequences:
+- Any change to either input file may renumber segments. Stage 3+ artifacts referencing Stage 2 outputs must be reconciled after such a change.
+- Cross-page narration merging is bounded by `needs_review` and chapter boundaries; it never silently spans them.
+- Mid-page chapter heading splits the page text deterministically; the contributing `text_unit_id` appears in `source_unit_ids` of both the prior chapter's last segment and the new chapter's first segment.
+- Re-running transform with the same two inputs MUST produce byte-identical `volume_index.json` and `segments/*.json` (asserted by `test_runner.py::test_determinism`).
+
+---
+
+## Scope
+
+In:
+- New `stages/transform/` modules: `__init__.py`, `runner.py`, `chapters.py`, `segments.py`, `quotes.py`, `validation.py`, `__main__.py` (CLI parity with prepare).
+- New `automations/ln_voice_over_v2/series/templates/story_profile.default.json` — packaged default series config (default heading regex set lives here, not in Python).
+- Public contract change: add `display_name: str` to `ChapterIndexEntry` in `stages/transform/contracts.py`. Required, non-empty.
+- A volume-scoped runner that reads `<volume>/prepared/volume.json`, resolves a `story_profile.json` (per-series override or packaged template fallback), and writes `<volume>/volume_index.json` plus `<volume>/segments/chapter_XX[_N].json`.
+- A cross-artifact validator added to `pipeline/validators.py`, **called inside `run_transform` before any file write**.
+- Unit + runner tests under `tests/automations/ln_voice_over_v2/stages/transform/`.
+- Rewrites to `automations/ln_voice_over_v2/AGENTS.md` (drop the "contract-only" rule; add the Disambiguation Protocol) and updates to the doc pages listed in "Doc Updates".
+
+Out:
+- No LLM calls, no dialogue attribution, no narration adaptation, no scene boundaries, no audio/visual outputs.
+- No new public contract keys on `Segment` (existing `parser_hints` is already `dict[str, Any]`).
+- No external runtime dependencies, no subprocess seams, no network.
+
+---
+
+## Outputs (recap from `docs/lnvo/02-transform.md`)
+
+- `<volume>/volume_index.json` — `VolumeIndex` artifact, `chapters[]` ordered.
+- `<volume>/segments/<chapter_id>.json` — `SegmentFile` artifact, one per chapter.
+
+ID conventions (locked):
+- `chapter_id`: `chapter_XX` or `chapter_XX_N` (e.g., `chapter_01`, `chapter_07_1`).
+- `segment_id`: `seg_NNNNNN`, 1-indexed start (`seg_000001`), unique per chapter.
+- `order` on both `ChapterIndexEntry` and `Segment`: 0-indexed dense.
+- `text_unit_id`: read what `stages/prepare/text_units.py` emits today — 0-indexed `unit_NNNNNN`.
+
+---
+
+## Series Config Resolution (v3 — replaces v2 inline-defaults design)
+
+1. Stage 2's runner resolves the active story profile in this order:
+   1. `<data_root>/<series>/config/story_profile.json` (per-series override; preferred).
+   2. `automations/ln_voice_over_v2/series/templates/story_profile.default.json` (packaged template; fallback).
+2. Both files share the `StoryProfile` shape defined in `docs/lnvo/00-series-parameters.md`. The contract is unchanged — `rules: dict[str, Any]`.
+3. Conventional keys this stage reads from `rules`:
+   - `rules.chapter_headings: list[str]` — ordered list of Python regex patterns. First match on a line wins.
+   - `rules.subchapters: bool` (optional; default `false`) — when `true`, allow `chapter_XX_N` even without a fractional numeric capture (used when the heading style itself signals subchapters, e.g., `◇`).
+4. Packaged-template default content:
+
+   ```json
+   {
+     "schema_version": 1,
+     "profile_id": "default",
+     "display_name": "Default Story Profile",
+     "rules": {
+       "chapter_headings": [
+         "^\\s*(?:Prologue|Epilogue|Afterword|Interlude)\\b",
+         "^\\s*Chapter\\s+(?P<num>\\d+(?:\\.\\d+)?)\\b",
+         "^\\s*第\\s*\\d+\\s*章"
+       ],
+       "subchapters": false
+     }
+   }
+   ```
+5. A per-series override file is created **only when the target series needs different rules** — this is a user/operator action, not Stage 2's responsibility. The runner does not auto-copy the template; it just reads either the override or the packaged default and proceeds.
+6. The runner logs at `INFO` which file resolved (override path or packaged template), so a re-run can be replicated.
+
+---
+
+## Chapter Detection Strategy
+
+1. **Input:** ordered `PreparedTextUnit`s (page-level). Each unit's `text` may contain a chapter heading anywhere within it.
+2. **Heading source:** the resolved `story_profile.json` (see "Series Config Resolution"). Patterns are compiled at runner start with `re.IGNORECASE | re.MULTILINE`.
+3. **Per-page scan.** For each `text_unit` in order, walk the unit's `text` line by line. Record the first heading match on the page and capture:
+   - The matched line text (for `display_name`).
+   - The byte offset of the match line within the unit's `text`.
+   - The captured `num` group if present (for subchapter numbering).
+4. **Boundary rule (mid-page split).** When a heading matches at line `L` within a page's text:
+   - The slice before the line break preceding `L` (the page text up to but not including line `L`) stays with the **prior** chapter; it becomes (or extends) the prior chapter's last narration segment.
+   - Line `L` and everything after start the **new** chapter; the heading line is included verbatim in the new chapter's first narration segment.
+   - The same `text_unit_id` appears in `source_unit_ids` of both the prior chapter's tail segment and the new chapter's head segment when a mid-page split occurs.
+   - If a page contains multiple heading matches (rare), apply this rule recursively to each.
+5. **`display_name` derivation.** For each chapter:
+   - Use the matched heading line, NFC-normalized, with leading/trailing whitespace trimmed and trailing punctuation kept intact. Example matches: `"Prologue"`, `"Chapter 7"`, `"Chapter 7.1"`, `"第 1 章"`.
+   - For the fallback single-chapter case (no heading anywhere), use `"Chapter 1"`.
+6. **Subchapter suffix (`_N`).** Emit `chapter_XX_N` when the heading regex captures a fractional `num` (e.g., `"Chapter 7.1"` → `chapter_07_1`) **or** when `rules.subchapters` is `true` and the same `XX` recurs.
+7. **Numbering.** `chapter_id` suffix is 1-indexed (`chapter_01`); `ChapterIndexEntry.order` is 0-indexed dense.
+8. **Fallback.** If no heading matches anywhere in the volume, emit a single `chapter_01` with `display_name = "Chapter 1"`; log a `WARNING`.
+9. **Heading text is NOT discarded** — it lives in the first narration segment's `text` so the narrator speaks it at generation, AND it surfaces structurally as `ChapterIndexEntry.display_name` for video-overlay use.
+
+---
+
+## Segment Creation Strategy
+
+1. **Per-chapter walk.** Iterate the chapter's `PreparedTextUnit`s in volume `order`.
+2. **`needs_review` handling.** A unit with `needs_review: true` emits a **single placeholder segment**:
+   - `text = "[needs_review:unit_NNNNNN]"` (non-empty, deterministic).
+   - `parser_hints = {"quote_candidate": false, "needs_review": true}`.
+   - `source_unit_ids = (<that unit_id>,)`.
+   - Acts as a hard segmentation boundary: cross-page narration merging and quote tokenization do not span across this unit.
+3. **Quote tokenizer (`stages/transform/quotes.py`).** Stream the chapter's contributing text through a finite-state tokenizer:
+   - Recognized opening/closing pairs: ASCII `"…"`, curly `“…”`, single curly `‘…’` (only as opener when preceded by whitespace or paragraph start), Japanese `「…」` and `『…』`.
+   - Glyphs are preserved verbatim in segment `text`; they are structural signals, not folded to ASCII.
+   - Emit alternating `NARRATION` runs and `QUOTE` spans, each carrying its contributing `text_unit_id`s in order.
+4. **Segment emission rules.**
+   - `QUOTE` token → one `Segment` with `text = <opening + body + closing>`, `parser_hints = {"quote_candidate": true, "quote_style": "<ascii|curly|jp-square|jp-double|single>"}`.
+   - `NARRATION` run (whitespace-trimmed, non-empty) → one `Segment` with `parser_hints = {"quote_candidate": false}`.
+   - Whitespace-only runs after trim are dropped.
+5. **Narration grouping across pages.** A `NARRATION` token may span consecutive `text_units` only when no `QUOTE`, no chapter boundary, and no `needs_review` boundary lies between them. The resulting segment's `source_unit_ids` lists every contributing unit in page order.
+6. **No splitting of long narration.** Stage 4 (scenes) owns beat sizing.
+7. **No splitting of dialogue.** Quote text is kept intact.
+8. **`segment_id` numbering.** Sequential per chapter starting at `seg_000001`. Reset on chapter change. `order` 0-indexed dense.
+9. **Whitespace normalization.** NFC unicode normalization before tokenization. Collapse runs of internal blank lines to a single `\n\n`; strip leading/trailing whitespace; preserve single newlines inside text.
+
+---
+
+## Quote Parsing Edge Cases
+
+| Case | Resolution |
+| --- | --- |
+| Smart apostrophe inside a word (`it's`) | Single-quote opener requires preceding whitespace/paragraph start; mid-word `'` stays in narration. This heuristic is Stage 2's structural-only line. |
+| Nested quotes (`"He said, 'no.'"`) | Outer pair forms the segment; inner pair literal. |
+| Unmatched open quote | Treat the run as narration; add `parser_hints.quote_unmatched: true`. Logged `WARNING`. |
+| Quote span crosses a page boundary (no `needs_review` between) | One segment; `source_unit_ids` lists both pages. |
+| Quote span would cross a `needs_review` page | Close heuristically at the page-A boundary; set `quote_unmatched: true`. |
+| Italic emphasis (`*word*`/`_word_`) | Ignored. |
+| Multi-paragraph quoted span | One segment; internal blank lines preserved. |
+| Em-dash dialogue (`— Hello`) | Treated as narration (no profile rule yet — Q5 deferred). |
+| Curly-quote with missing close | Same as ASCII unmatched-open. |
+| Heading line inside a quote | Impossible by construction (heading regex anchored at line start runs first). |
+
+---
+
+## Page Provenance
+
+- `Segment.source_unit_ids` lists every `text_unit_id` that contributed at least one character, in page order.
+- Mid-page heading splits cause one unit to appear in two adjacent segments. The cross-validator accepts this.
+- Validator (§"Validation") requires every `text_unit_id` in `prepared/volume.json` — including `needs_review` units — to appear in some segment's `source_unit_ids`. Illustration-only pages with empty `text` and `needs_review: false` are exempt.
+- Heading lines that triggered chapter detection are always preserved in the first narration segment of the new chapter.
+
+---
+
+## Validation
+
+### Stage-local (`stages/transform/validation.py`)
+Artifact-internal invariants, mirrors `stages/prepare/validation.py`:
+- Pydantic strict parse (already guaranteed by `extra="forbid"`).
+- `volume_index.chapters[].chapter_id` unique; `order` 0-indexed dense; no gaps.
+- `volume_index.chapters[].segments_file == f"segments/{chapter_id}.json"`.
+- `volume_index.chapters[].display_name` non-empty after trim.
+- For each `SegmentFile`: `segment_id` matches `seg_NNNNNN`, 1-indexed dense suffix; `order` 0-indexed dense; `text` non-empty after trim.
+
+### Cross-artifact (`pipeline/validators.py`, called inside `run_transform` before any write)
+New function `validate_transform_against_prepared(index, segments, prepared) -> None`, mirroring `validate_dialogue_against_segments`:
+- Series + volume match across all artifacts.
+- Each `SegmentFile.chapter_id` matches the corresponding `VolumeIndex.chapters[i].chapter_id`.
+- Every `Segment.source_unit_id` resolves to a `text_unit_id` in `prepared/volume.json`.
+- Coverage: union of `source_unit_ids` across all segments ⊇ every `text_unit_id` in `prepared/volume.json`, except illustration-only `text_units` (empty `text`, `needs_review: false`).
+
+### Warning-level
+- A chapter contains zero quote candidates.
+- Heading fallback fired (single chapter for the whole volume).
+- Unmatched-quote heuristic fired on any chapter.
+- Any `needs_review` placeholder segment emitted.
+
+---
+
+## Runner + CLI Shape
+
+- `stages/transform/runner.py`:
+  - `@dataclass(frozen=True) TransformConfig(series, volume, data_root: Path = paths.DEFAULT_PROJECT_DATA_ROOT, story_profile: ProfileId | None = None, force: bool = False)`.
+  - `@dataclass(frozen=True) TransformResult(volume_index_path, volume_index, segments_dir, chapter_count, segment_count, needs_review_segment_count, story_profile_source: Path)`.
+  - `run_transform(config: TransformConfig) -> TransformResult`:
+    1. Load `prepared/volume.json` via `load_json_contract(prepared_volume_path, PreparedVolume)`.
+    2. Resolve `story_profile.json` per "Series Config Resolution"; record which file won in `TransformResult.story_profile_source`; log at `INFO`.
+    3. Compile heading regex set from `story_profile.rules.chapter_headings`.
+    4. Build chapter splits (`chapters.detect_chapters(prepared, headings)`).
+    5. Build segments per chapter (`segments.build_segments(prepared, chapter_splits)`).
+    6. Construct `VolumeIndex` (with `display_name` per entry) and `SegmentFile` Pydantic models.
+    7. Run stage-local `validation.validate_transform_artifacts(index, segments)`.
+    8. Run cross-validator `pipeline.validators.validate_transform_against_prepared(index, segments, prepared)` — **before any write**.
+    9. If `config.force`: `shutil.rmtree(segments_dir, ignore_errors=True)` and `volume_index_path.unlink(missing_ok=True)`.
+    10. `save_json_contract(volume_index_path, index)`; for each `SegmentFile`, `save_json_contract(segment_file_path(...), segment_file)`.
+  - No `Callable` seam kwargs. No network. No subprocess.
+- `stages/transform/__main__.py`: argparse wrapper with `--series`, `--volume`, `--data-root`, `--story-profile`, `--force`. Mirrors `stages/prepare/__main__.py`.
+
+---
+
+## Contract Change Diff
+
+`automations/ln_voice_over_v2/stages/transform/contracts.py` — add one required field:
+
+```python
+class ChapterIndexEntry(ContractModel):
+    chapter_id: ChapterId
+    order: int = Field(ge=0)
+    segments_file: ArtifactPath
+    display_name: str = Field(min_length=1)   # NEW
+```
+
+`docs/lnvo/02-transform.md` — Volume Index table gains a `display_name` row marked required.
+
+Existing test fixture in `tests/automations/ln_voice_over_v2/test_contracts.py::_volume_index()` will need a `display_name="Chapter 1"` field to keep round-tripping.
+
+---
+
+## Tests
+
+Place under `tests/automations/ln_voice_over_v2/stages/transform/` (mirrors `prepare/`).
+
+### `test_chapters.py`
+
+By the time this slice runs, T1 has already added `display_name` to `ChapterIndexEntry`. The chapter detector returns `ChapterIndexEntry` instances plus a separate, private per-unit slice helper (one entry per contributing `text_unit`, recording the unit id and the text contribution — possibly partial after a mid-page split). That helper is internal to `chapters.py` and feeds T4 segmentation; it is not a public contract.
+
+- Heading at page top → page assigned wholly to new chapter.
+- Mid-page heading split → pre-heading text stays with prior chapter; heading + post-heading text starts new chapter; the shared `text_unit_id` appears in the per-unit-slice helper for both neighbours. Assert exact text and exact `text_unit_id` membership at the helper layer.
+- Multiple headings on one page → recursive split.
+- No heading anywhere → single `ChapterIndexEntry(chapter_id="chapter_01", order=0, display_name="Chapter 1", segments_file="segments/chapter_01.json")`, WARNING logged.
+- Subchapter numbering — `"Chapter 7.1"` → `chapter_id == "chapter_07_1"`, `display_name == "Chapter 7.1"`.
+- Prologue + Chapter 1 + Epilogue → three `ChapterIndexEntry`s with `order 0/1/2` and respective `display_name`s.
+- Per-series override beats packaged template (write a custom `story_profile.json` to `tmp_path` and assert the override wins).
+
+### `test_quotes.py` (string-in, tokens-out; no contract knowledge)
+- ASCII, curly, JP `「」`, JP `『』` tokenization.
+- Apostrophe-not-opener (`It's a fine day` → single `NARRATION` token).
+- Single-quote-as-opener (`'Hello,' she said.` → `QUOTE`, `NARRATION`).
+- Nested quotes — single outer `QUOTE`, inner pair literal.
+- Unmatched open → `quote_unmatched=True`.
+- Multi-paragraph quote → single `QUOTE` with internal blank line preserved.
+
+### `test_segments.py`
+- Cross-page narration merge → one segment with `source_unit_ids == ("unit_000005", "unit_000006")`.
+- `needs_review` boundary blocks merge → three segments (A narration, B placeholder, C narration). Assert exact placeholder `text` and `parser_hints`.
+- Illustration-only page skipped → no segment, cross-validator clean.
+- `segment_id` numbering resets per chapter.
+- Exact `parser_hints` payloads for quote vs narration.
+
+### `test_runner.py`
+- Happy path on synthetic `prepared/volume.json` with Prologue + Chapter 1 + Epilogue → three `SegmentFile`s, `VolumeIndex` with `display_name`s present. Assert exact file paths under `tmp_path`.
+- Cross-validator called before write — patch `pipeline.validators.validate_transform_against_prepared` to raise; assert no `volume_index.json` or `segments/*.json` written.
+- `--force` wipes pre-existing `segments/chapter_99.json`.
+- Determinism — two runs with identical inputs produce byte-equal output files.
+- Series config resolution — when `<data_root>/<series>/config/story_profile.json` exists, it wins over the packaged template; assert `TransformResult.story_profile_source` reflects the chosen file.
+- CLI smoke via `python -m automations.ln_voice_over_v2.stages.transform`.
+
+### `tests/automations/ln_voice_over_v2/test_validators.py` — extensions
+- `validate_transform_against_prepared` happy path.
+- Unknown `source_unit_id` → `missing_text_unit`.
+- Missing coverage (non-empty, non-`needs_review` unit absent from every `source_unit_ids`) → `missing_coverage`.
+- Duplicate `order` within a chapter → `duplicate_order`.
+- Gapped `order` (skips 1) → `nonconsecutive_order`.
+- Bad `segments_file` path (not matching `segments/<chapter_id>.json`) → `bad_segments_file`.
+
+### Verification command
+```
+ruff format --check .
+ruff check .
+pytest tests/automations/ln_voice_over_v2/
+```
+All three must pass before the slice is reported done.
+
+---
+
+## Doc Updates
+
+All listed below are within scope of Stage 2 slices:
+
+1. **`automations/ln_voice_over_v2/AGENTS.md` — REWRITE (user-approved).**
+   - Remove the "Stages other than `stages/prepare/` remain contract-only" rule. Every stage is allowed whatever modules, runner, CLI, or pure-function helpers it needs to deliver its contract.
+   - Keep the rule that public contract keys, enum values, artifact paths, and stage names require user confirmation before changing.
+   - **Add a "Disambiguation Protocol" section:** when implementation depends on volume-specific content that is not captured in `story_profile.json` or other config (heading style, dialogue convention, glyph set, character names, etc.), spawn one or more Codex agents to read `<data_root>/<series>/<volume>/prepared/volume.json` or `source/` excerpts. Agents must surface findings with concrete page references before code is written. No guessing.
+   - **Add a "Series Config" section** documenting that `<data_root>/<series>/config/story_profile.json` is the per-series override location and the packaged template `automations/ln_voice_over_v2/series/templates/story_profile.default.json` is the fallback.
+
+2. **`docs/lnvo/02-transform.md`:**
+   - Replace `parser_hints` example `quote_like: false` with `quote_candidate: false`.
+   - Document optional `parser_hints` keys this stage emits: `quote_candidate`, `quote_style`, `quote_unmatched`, `needs_review`.
+   - Add `display_name` (required, non-empty) to the Volume Index table.
+   - Note the `chapter_id` ↔ `order` indexing convention and `seg_NNNNNN` 1-indexed start.
+   - Add a short paragraph naming the inputs: `<volume>/prepared/volume.json` (always) and either `<data_root>/<series>/config/story_profile.json` or the packaged default template.
+
+3. **`docs/lnvo/00-series-parameters.md`:**
+   - Add a short paragraph under "Story Profile" naming the conventional `rules` keys this stage reads: `chapter_headings: list[str]`, `subchapters: bool`.
+   - Reference the packaged template path.
+
+4. **`docs/lnvo/contracts-index.md`:**
+   - Clarify that the `seg_NNNNNN` suffix range begins at `seg_000001` (the regex shows the *pattern*, not the starting value).
+
+5. **`automations/ln_voice_over_v2/README.md`:**
+   - Add a brief Transform stage section describing the CLI flags and re-run semantics (parallel to the existing Prepare section).
+
+6. **Repository asset:**
+   - New file `automations/ln_voice_over_v2/series/templates/story_profile.default.json` with the default heading regex set (see "Series Config Resolution" §4).
+
+---
+
+## Implementation Slices (v3.2 ordering, after approval)
+
+0. **Slice T0 — AGENTS.md rewrite + packaged template + docs prep.** *(DONE, branch `feat/lnvo-v2-transform-t0`, commit `aa401ef`.)*
+   - Edited `automations/ln_voice_over_v2/AGENTS.md` (dropped contract-only rule, added Disambiguation Protocol, added Series Config section).
+   - Added `automations/ln_voice_over_v2/series/templates/story_profile.default.json`.
+   - Updated `docs/lnvo/02-transform.md` and `docs/lnvo/00-series-parameters.md`.
+
+1. **Slice T1 — `ChapterIndexEntry.display_name` contract migration.** Tiny mechanical commit that lands the new required field plus the only existing fixture that constructs the model. Files:
+   - `automations/ln_voice_over_v2/stages/transform/contracts.py` — add `display_name: str = Field(min_length=1)` to `ChapterIndexEntry`.
+   - `tests/automations/ln_voice_over_v2/test_contracts.py` — update the `_volume_index()` fixture at line 241 to include `display_name="Chapter 1"` so the existing round-trip test keeps passing.
+
+2. **Slice T2 — chapter detection + tests.** Pure functions; reads `StoryProfile`; emits `ChapterIndexEntry` directly (now safe since T1 has landed) plus a private per-unit text-slice helper for partial-page bookkeeping. (`chapters.py`, `test_chapters.py`.)
+
+3. **Slice T3 — quote tokenizer + tests.** Pure function over a string; no contract knowledge. (`quotes.py`, `test_quotes.py`.)
+
+4. **Slice T4 — segmentation + provenance + tests.** Wires T2+T3 into `Segment` emission; handles `needs_review` placeholders and cross-page narration merging. (`segments.py`, `test_segments.py`.)
+
+5. **Slice T5 — stage-local + cross-artifact validators + tests.** Files:
+   - `automations/ln_voice_over_v2/stages/transform/validation.py` (stage-local invariants).
+   - `automations/ln_voice_over_v2/pipeline/validators.py` (cross-validator `validate_transform_against_prepared`).
+   - `tests/automations/ln_voice_over_v2/test_validators.py` (extends with new cross-validator cases).
+
+6. **Slice T6 — runner + CLI + e2e tests.** (`runner.py`, `__main__.py`, `test_runner.py`.) Runner calls stage-local validator then cross-validator before any file write.
+
+7. **Slice T7 — README + `contracts-index.md` polish.**
+
+Each slice is a separately reviewable Codex task with bounded files. Every slice's commit must leave `ruff format --check .`, `ruff check .`, and `pytest tests/automations/ln_voice_over_v2/` all green.
+
+---
+
+## Disambiguation Protocol (Codex agent rule)
+
+Whenever a planning or implementation step needs to know something about the actual content of a volume — examples below — spawn Codex agent(s) to read the real text first:
+
+- Does this LN edition use em-dash dialogue or quote glyphs?
+- What heading style does it use? Is `Chapter 7` literal or `◇ 7話`?
+- Do chapter headings appear at the top of a recto, or anywhere on a page?
+- Are there illustrations that contain readable text?
+- Do quoted spans nest? Do they cross paragraphs?
+
+Agents must:
+- Read from `<data_root>/<series>/<volume>/prepared/volume.json` or `source/` excerpts, not guess.
+- Report findings with concrete `text_unit_id`s or page numbers.
+- Multiple agents may be spawned in parallel to sample different parts of a volume; for multi-volume series, sample multiple volumes.
+
+This rule is added to package `AGENTS.md` in Slice T0 so it applies to all future LNVO v2 work, not just Stage 2.
+
+---
+
+## ADR
+
+- **Decision:** Implement Stage 2 as a deterministic, code-only transformer with config-driven chapter detection, quote-aware segmentation that preserves heading text in narration, `needs_review`-safe placeholder segments, and a cross-validator called inside the runner before writes. Drop the package's stage-contract-only rule. Add a Disambiguation Protocol rule. Ship a packaged default series template.
+- **Drivers:** Stage-boundary discipline; deterministic ID stability; page-provenance round trip.
+- **Alternatives considered:** sentence- and paragraph-level segmentation (rejected — over-fragments / loses dialogue structure); manual chapter map (deferred as future override); whole-page reassignment on mid-page headings (rejected — silent migration); skipping `needs_review` units (rejected — coverage conflict); inline-in-`chapters.py` heading defaults (rejected — series authors won't discover them); hardcoded-in-`series/contracts.py` factory (rejected — layering smell). Config-driven via packaged template + per-series override is the chosen path.
+- **Locked decisions:**
+  - `text_unit_id` 0-indexed; `segment_id` 1-indexed; `order` 0-indexed dense.
+  - `needs_review` units get a non-empty placeholder segment; coverage is a hard validator requirement.
+  - Cross-validator runs inside `run_transform` before any file write.
+  - `ChapterIndexEntry.display_name: str` required, non-empty.
+  - Quote glyphs (curly, JP) are preserved verbatim — not folded to ASCII.
+  - Heading text is duplicated: spoken (in first narration segment of the new chapter) AND structural (`display_name` on the index entry).
+  - Em-dash dialogue is treated as narration; no profile rule yet.
+  - Default chapter-heading regex set lives in the packaged template `automations/ln_voice_over_v2/series/templates/story_profile.default.json`. No inline Python defaults.
+  - Stage-contract-only rule in `automations/ln_voice_over_v2/AGENTS.md` is removed in slice T0.
+  - Disambiguation Protocol is added in slice T0 and applies to all future LNVO v2 work.
+- **Consequences:**
+  - Stage 3 must treat `quote_candidate: true` as a candidate only and run its own confirmation.
+  - Stage 3 must route `needs_review` placeholder segments to human review.
+  - Stage 4 still owns long-narration splitting.
+  - Stage 5 (generation) gets `ChapterIndexEntry.display_name` for video-overlay use; the narrator also speaks the heading because it stays in the first segment's narration text.
+  - Operators bootstrapping a new series do not need to copy the template — the runner falls back to it transparently — but may copy and edit `<data_root>/<series>/config/story_profile.json` when overrides are needed.
+- **Follow-ups:** none open. All v1/v2 blockers and questions are resolved.
+
+---
+
+*This plan is `pending approval` at revision **v3.2**. Slice T0 has been executed and committed on branch `feat/lnvo-v2-transform-t0` (`aa401ef`). No further code, contracts, or test files have been modified. Architect v1: ITERATE → addressed in v2. Critic v1: ITERATE → addressed in v2. v3 incorporated user decisions (B1, Q2, Q4, Q5, Q8) and added the Disambiguation Protocol. Architect v3: APPROVE. Critic v3: ITERATE — two slice-ordering polishes; v3.1 attempted a `ChapterSplit` shim that the user (correctly) rejected as over-engineered. v3.2 fixes the root cause by reordering: contract migration is now slice T1, eliminating the shim entirely.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,62 +3,69 @@
 ## Project Overview
 
 A Python-based computer control agent. The project has two layers:
+
 - **Library** (`src/assistant/`): reusable building blocks for computer control, usable by anyone
 - **Automations** (`automations/`): personal scripts that import from the library for specific use cases
-
-The library starts flat — modules are added as we build them. Structure emerges from usage, not speculation.
 
 ## Workflow Rules
 
 ### Scope Control
+
 - **One module/feature per edit session.** Never touch unrelated modules in the same session.
 - Each agent (subagent) must limit its edits to a single module or feature.
 - If a change requires touching multiple modules, keep the plan explicit and proceed module by module.
 
 ### Commit Discipline
+
 - **Pause and commit after tests pass.** Do not continue to the next feature without committing.
 - Use **Conventional Commits**: `feat(module):`, `fix(module):`, `refactor(module):`, `docs:`, `test:`, `chore:`.
-- Commit messages should explain *why*, not just *what*.
+- Commit messages should explain _why_, not just _what_.
 - When a feature slice is complete and verification passes, stage only the files in scope and commit without waiting for an extra prompt, unless the user asks not to commit.
 
 ### Branch Management (GitHub Flow)
+
 - `main` is always deployable.
 - Create a feature branch for each new feature: `feat/short-description`.
 - Fix branches: `fix/short-description`.
-- Remind the user to merge completed feature branches back to main.
-- Remind the user to delete merged branches.
 
 ### Documentation
+
 - Every module must have a module-level docstring explaining its purpose.
 - Public functions use **Google-style docstrings** — skip docstrings for trivial/self-explanatory functions.
 
 ## Code Style
 
 ### Formatting & Linting
+
 - **Ruff** is the single tool for formatting and linting. Run `ruff check .` and `ruff format .`.
 - If handwritten code by the user does not pass ruff, notify them.
 
 ### Type Hints
+
 - **Pragmatic**: type all public function signatures and complex internal functions.
 - Skip type hints for trivial local variables and obvious cases.
 
 ### Error Handling
+
 - **No `try/except` unless genuinely necessary** (e.g., external I/O, network calls, user input).
 - Never use bare `except:` or `except Exception:` as a catch-all.
 - Let errors propagate naturally — don't swallow them.
 
 ### Code Comments
+
 - Write brief comments on non-trivial blocks explaining **what** the block does and **why** this approach was chosen.
 - Target audience: the user and future AI assistants reading the code.
 - Key things to call out: design trade-offs, platform-specific behavior, non-obvious constraints, and links to related modules.
 - Do NOT comment obvious code. `# increment counter` above `counter += 1` is noise.
 
 ### General
+
 - No unnecessary abstractions. Three similar lines > premature abstraction.
 - No speculative features or "just in case" code.
 - Imports: stdlib first, then third-party, then local. Ruff handles ordering.
 
 ## Testing
+
 - **pytest** is the testing framework.
 - Tests live in `tests/` mirroring the `src/` structure.
 - Test file naming: `test_<module>.py`.
@@ -67,12 +74,14 @@ The library starts flat — modules are added as we build them. Structure emerge
 ## Two-Tier Rules
 
 ### Library (`src/assistant/`)
+
 - Changes require careful boundary checks and backward compatibility.
 - Must maintain backward compatibility with existing automations.
 - Must have tests before merging.
 - Public APIs must be typed and documented.
 
 ### Automations (`automations/`)
+
 - Greater autonomy allowed — a well-written planning prompt should be sufficient to generate an automation.
 - Each automation is a self-contained script or module.
 - Automations import from the library but never modify it.
@@ -83,6 +92,7 @@ The library starts flat — modules are added as we build them. Structure emerge
   automations or unrelated repo docs.
 
 ## Documentation Maintenance
+
 - The root `README.md` describes the **library** (`src/assistant/`): its modules, CLI commands, and roadmap. It should not document automations — those have their own READMEs.
 - When library modules, CLI commands, or the roadmap change, update the root `README.md` to match.
 - Each automation under `automations/` should have its own `README.md` documenting its purpose and CLI usage.
@@ -92,6 +102,7 @@ The library starts flat — modules are added as we build them. Structure emerge
   contracts, and planning notes.
 
 ## Reminders for Codex
+
 - Always read a file before editing it.
 - Notify the user if their code doesn't match the style guidelines.
 - After completing a feature: run focused verification, stage only in-scope files, and commit once checks pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,12 +14,12 @@ implementers.
 
 ## Project Map
 
-| Area | Role |
-| --- | --- |
-| `src/assistant/` | reusable library code. |
-| `automations/` | self-contained personal automations. |
-| `docs/lnvo/` | repo-tracked LNVO reference docs, viewable from Obsidian. |
-| package `CONTEXT.md` | local vocabulary and execution context for one package. |
+| Area                 | Role                                                      |
+| -------------------- | --------------------------------------------------------- |
+| `src/assistant/`     | reusable library code.                                    |
+| `automations/`       | self-contained personal automations.                      |
+| `docs/lnvo/`         | repo-tracked LNVO reference docs, viewable from Obsidian. |
+| package `CONTEXT.md` | local vocabulary and execution context for one package.   |
 
 Automation sub-projects are self-contained. Apply only the relevant
 `AGENTS.md` / `CLAUDE.md` files and the files they explicitly name. Ignore
@@ -60,10 +60,6 @@ required keys.
 ## Documentation Model
 
 `docs/lnvo/` is the canonical Markdown source for LNVO reference material.
-Obsidian is the editing and canvas surface for those files.
-
-External Obsidian notes and Canvas sketches are working material. Promote only
-stable reference docs into the repo.
 
 README files are user-facing entry points. `CONTEXT.md` files are agent-facing
 local context.

--- a/automations/ln_voice_over_v2/CONTEXT.md
+++ b/automations/ln_voice_over_v2/CONTEXT.md
@@ -20,6 +20,14 @@ quote-like candidates, and resolves chapter perspective.
 adapted narration beats, dialogue beats, and visual choices.
 
 **Generation** records audio and visual media output contracts from final scenes.
+Spoken narration resolves to the beat speaker when present; otherwise it uses
+the reserved `Narrator` voice key. For Classroom of the Elite, `Narrator`
+defaults to Ayanokouji's voice, but chapters with another detected narrator
+should use that character's voice.
+
+Provider credentials stay outside LNVO v2 runtime artifacts. Hume voices require
+`HUME_API_KEY` in the Voice Tuning environment; LNVO references accepted voice
+keys and engine ids, but does not store or print provider secrets.
 
 ## Canonical Data
 

--- a/automations/ln_voice_over_v2/common/paths.py
+++ b/automations/ln_voice_over_v2/common/paths.py
@@ -15,6 +15,19 @@ def series_root(data_root: Path, series: SeriesId) -> Path:
     return data_root / series
 
 
+def characters_config_path(data_root: Path, series: SeriesId) -> Path:
+    """Return the series character registry config path.
+
+    Args:
+        data_root: Runtime data root containing all series data.
+        series: Series identifier.
+
+    Returns:
+        Path to the series `characters.json` config file.
+    """
+    return series_root(data_root, series) / "config" / "characters.json"
+
+
 def volume_root(data_root: Path, series: SeriesId, volume: VolumeId) -> Path:
     """Return the runtime volume root."""
     return series_root(data_root, series) / volume

--- a/automations/ln_voice_over_v2/series/contracts.py
+++ b/automations/ln_voice_over_v2/series/contracts.py
@@ -39,6 +39,24 @@ class CharacterRegistry(ContractModel):
         """Return whether a canonical character name exists."""
         return any(character.name == name for character in self.characters)
 
+    def resolve(self, name: str) -> str | None:
+        """Resolve an exact character name or alias to its canonical name.
+
+        Args:
+            name: Raw character name or alias to resolve.
+
+        Returns:
+            The canonical character name when `name` exactly matches a
+            character name or alias after trimming; otherwise `None`.
+        """
+        candidate = name.strip()
+        for character in self.characters:
+            if character.name == candidate:
+                return character.name
+            if candidate in character.aliases:
+                return character.name
+        return None
+
 
 class VoiceMappingEntry(ContractModel):
     """Accepted TTS voice configuration for one voice key."""

--- a/automations/ln_voice_over_v2/series/loader.py
+++ b/automations/ln_voice_over_v2/series/loader.py
@@ -1,0 +1,20 @@
+"""Series-level config loaders for LNVO v2."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..common.json_io import load_json_contract
+from .contracts import CharacterRegistry
+
+
+def load_character_registry(path: Path) -> CharacterRegistry:
+    """Load a `CharacterRegistry` from disk using the strict JSON contract loader.
+
+    Args:
+        path: Path to a `characters.json` file.
+
+    Returns:
+        Parsed character registry.
+    """
+    return load_json_contract(path, CharacterRegistry)

--- a/automations/ln_voice_over_v2/stages/dialogue/__main__.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/__main__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ...common import paths
 from ...common.errors import ContractValidationError
+from .agent import DEFAULT_DIALOGUE_TIMEOUT_SECONDS
 from .runner import (
     DialogueConfig,
     DialogueVolumeConfig,
@@ -50,6 +51,7 @@ def _run_single_chapter(args: argparse.Namespace) -> int:
         chapter_id=args.chapter,
         data_root=args.data_root,
         force=args.force,
+        timeout_seconds=args.timeout,
     )
     try:
         result = run_dialogue(config)
@@ -71,6 +73,7 @@ def _run_volume(args: argparse.Namespace) -> int:
         data_root=args.data_root,
         force=args.force,
         workers=args.workers,
+        timeout_seconds=args.timeout,
     )
     try:
         result = run_dialogue_volume(config)
@@ -117,6 +120,15 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=4,
         help="Concurrent chapters when running the whole volume (default 4).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_DIALOGUE_TIMEOUT_SECONDS,
+        help=(
+            "Codex subprocess timeout in seconds per chapter "
+            f"(default {DEFAULT_DIALOGUE_TIMEOUT_SECONDS})."
+        ),
     )
     return parser
 

--- a/automations/ln_voice_over_v2/stages/dialogue/__main__.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/__main__.py
@@ -9,11 +9,19 @@ from pathlib import Path
 
 from ...common import paths
 from ...common.errors import ContractValidationError
-from .runner import DialogueConfig, run_dialogue
+from .runner import (
+    DialogueConfig,
+    DialogueVolumeConfig,
+    run_dialogue,
+    run_dialogue_volume,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
     """Run the dialogue-stage CLI.
+
+    With `--chapter`, attribute that one chapter. Without it, attribute every
+    chapter in the volume index, dispatching `--workers` chapters concurrently.
 
     Args:
         argv: Optional argument vector. Defaults to `sys.argv[1:]`.
@@ -30,6 +38,12 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"{parser.prog}: error: {exc}\n")
         return 2
 
+    if args.chapter is not None:
+        return _run_single_chapter(args)
+    return _run_volume(args)
+
+
+def _run_single_chapter(args: argparse.Namespace) -> int:
     config = DialogueConfig(
         series=args.series,
         volume=args.volume,
@@ -40,8 +54,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         result = run_dialogue(config)
     except ContractValidationError as exc:
-        for problem in exc.problems:
-            sys.stderr.write(f"{problem.code}: {problem.path}: {problem.message}\n")
+        _write_problems(exc)
         return 2
     except Exception as exc:
         sys.stderr.write(f"{exc}\n")
@@ -51,6 +64,42 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _run_volume(args: argparse.Namespace) -> int:
+    config = DialogueVolumeConfig(
+        series=args.series,
+        volume=args.volume,
+        data_root=args.data_root,
+        force=args.force,
+        workers=args.workers,
+    )
+    try:
+        result = run_dialogue_volume(config)
+    except ContractValidationError as exc:
+        _write_problems(exc)
+        return 2
+    except Exception as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+
+    for outcome in result.outcomes:
+        if outcome.error is not None:
+            sys.stderr.write(f"{outcome.chapter_id}: error: {outcome.error}\n")
+        elif outcome.result is not None and outcome.result.skipped:
+            sys.stdout.write(f"{outcome.chapter_id}: skipped (exists)\n")
+        elif outcome.result is not None:
+            sys.stdout.write(f"{outcome.result.dialogue_path}\n")
+
+    sys.stdout.write(
+        f"dialogue: {result.written} written, {result.skipped} skipped, {result.failed} failed\n"
+    )
+    return 1 if result.failed else 0
+
+
+def _write_problems(exc: ContractValidationError) -> None:
+    for problem in exc.problems:
+        sys.stderr.write(f"{problem.code}: {problem.path}: {problem.message}\n")
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m automations.ln_voice_over_v2.stages.dialogue",
@@ -58,9 +107,17 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--series", required=True)
     parser.add_argument("--volume", required=True)
-    parser.add_argument("--chapter", required=True)
+    parser.add_argument(
+        "--chapter", help="Chapter id (e.g. chapter_01). Omit to run every chapter."
+    )
     parser.add_argument("--data-root", type=Path, default=paths.DEFAULT_PROJECT_DATA_ROOT)
     parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Concurrent chapters when running the whole volume (default 4).",
+    )
     return parser
 
 

--- a/automations/ln_voice_over_v2/stages/dialogue/__main__.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/__main__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from ...common import paths
 from ...common.errors import ContractValidationError
 from .agent import DEFAULT_DIALOGUE_TIMEOUT_SECONDS
+from .chunking import DEFAULT_MAX_CANDIDATES_PER_CHUNK
 from .runner import (
     DialogueConfig,
     DialogueVolumeConfig,
@@ -52,6 +53,7 @@ def _run_single_chapter(args: argparse.Namespace) -> int:
         data_root=args.data_root,
         force=args.force,
         timeout_seconds=args.timeout,
+        max_candidates_per_chunk=args.max_candidates_per_chunk,
     )
     try:
         result = run_dialogue(config)
@@ -74,6 +76,7 @@ def _run_volume(args: argparse.Namespace) -> int:
         force=args.force,
         workers=args.workers,
         timeout_seconds=args.timeout,
+        max_candidates_per_chunk=args.max_candidates_per_chunk,
     )
     try:
         result = run_dialogue_volume(config)
@@ -128,6 +131,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Codex subprocess timeout in seconds per chapter "
             f"(default {DEFAULT_DIALOGUE_TIMEOUT_SECONDS})."
+        ),
+    )
+    parser.add_argument(
+        "--max-candidates-per-chunk",
+        type=int,
+        default=DEFAULT_MAX_CANDIDATES_PER_CHUNK,
+        help=(
+            "Maximum dialogue candidates per Codex attribution chunk "
+            f"(default {DEFAULT_MAX_CANDIDATES_PER_CHUNK})."
         ),
     )
     return parser

--- a/automations/ln_voice_over_v2/stages/dialogue/__main__.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/__main__.py
@@ -1,0 +1,80 @@
+"""Module-mode CLI for the LNVO v2 dialogue stage."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from ...common import paths
+from ...common.errors import ContractValidationError
+from .runner import DialogueConfig, run_dialogue
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the dialogue-stage CLI.
+
+    Args:
+        argv: Optional argument vector. Defaults to `sys.argv[1:]`.
+
+    Returns:
+        Process-style exit code.
+    """
+    _configure_logging()
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except argparse.ArgumentError as exc:
+        parser.print_usage(sys.stderr)
+        sys.stderr.write(f"{parser.prog}: error: {exc}\n")
+        return 2
+
+    config = DialogueConfig(
+        series=args.series,
+        volume=args.volume,
+        chapter_id=args.chapter,
+        data_root=args.data_root,
+        force=args.force,
+    )
+    try:
+        result = run_dialogue(config)
+    except ContractValidationError as exc:
+        for problem in exc.problems:
+            sys.stderr.write(f"{problem.code}: {problem.path}: {problem.message}\n")
+        return 2
+    except Exception as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+
+    sys.stdout.write(f"{result.dialogue_path}\n")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m automations.ln_voice_over_v2.stages.dialogue",
+        exit_on_error=False,
+    )
+    parser.add_argument("--series", required=True)
+    parser.add_argument("--volume", required=True)
+    parser.add_argument("--chapter", required=True)
+    parser.add_argument("--data-root", type=Path, default=paths.DEFAULT_PROJECT_DATA_ROOT)
+    parser.add_argument("--force", action="store_true")
+    return parser
+
+
+def _configure_logging() -> None:
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+    if any(getattr(handler, "_lnvo_dialogue_handler", False) for handler in root_logger.handlers):
+        return
+
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler._lnvo_dialogue_handler = True  # type: ignore[attr-defined]
+    root_logger.addHandler(handler)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/automations/ln_voice_over_v2/stages/dialogue/agent.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/agent.py
@@ -7,6 +7,10 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from ...common.errors import ContractValidationError, ValidationProblem
 from ...common.ids import SegmentId
 
+# Default per-chapter codex attribution timeout in seconds. Shared by the config
+# and CLI defaults so the value never drifts across the call chain.
+DEFAULT_DIALOGUE_TIMEOUT_SECONDS = 600
+
 
 class CandidateDecision(BaseModel):
     """Dialogue classification decision for one candidate segment."""
@@ -34,7 +38,7 @@ def run_codex_dialogue(
     *,
     model: str = "gpt-5.5",
     executable: str = "codex",
-    timeout_seconds: int = 180,
+    timeout_seconds: int = DEFAULT_DIALOGUE_TIMEOUT_SECONDS,
 ) -> DialogueProposal:
     """Run Codex in text-only mode and parse a dialogue proposal."""
     argv = [
@@ -58,8 +62,12 @@ def run_codex_dialogue(
             timeout=timeout_seconds,
             check=True,
         )
+    # `from None` suppresses the chained subprocess error: its `cmd`/`argv`
+    # carries the full prompt, which must not leak into a printed traceback.
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"codex dialogue timed out after {timeout_seconds}s") from None
     except subprocess.CalledProcessError as err:
-        raise RuntimeError(f"codex dialogue failed: {err.stderr}") from err
+        raise RuntimeError(f"codex dialogue failed: {err.stderr}") from None
 
     try:
         return DialogueProposal.model_validate_json(completed.stdout.strip())

--- a/automations/ln_voice_over_v2/stages/dialogue/agent.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/agent.py
@@ -1,0 +1,75 @@
+"""Codex-backed dialogue attribution agent."""
+
+import subprocess
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ...common.errors import ContractValidationError, ValidationProblem
+from ...common.ids import SegmentId
+
+
+class CandidateDecision(BaseModel):
+    """Dialogue classification decision for one candidate segment."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    segment_id: SegmentId
+    is_dialogue: bool
+    speaker_raw: str | None = None
+    reason: str = ""
+
+
+class DialogueProposal(BaseModel):
+    """Raw model proposal before deterministic normalization."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    decisions: tuple[CandidateDecision, ...]
+    narrator_raw: str | None = None
+    review_notes: tuple[str, ...] = ()
+
+
+def run_codex_dialogue(
+    prompt: str,
+    *,
+    model: str = "gpt-5.5",
+    executable: str = "codex",
+    timeout_seconds: int = 180,
+) -> DialogueProposal:
+    """Run Codex in text-only mode and parse a dialogue proposal."""
+    argv = [
+        executable,
+        "exec",
+        "-m",
+        model,
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--ignore-user-config",
+        "-s",
+        "read-only",
+        prompt,
+    ]
+    try:
+        completed = subprocess.run(  # noqa: UP022 - contract requires explicit stdout/stderr pipes.
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout_seconds,
+            check=True,
+        )
+    except subprocess.CalledProcessError as err:
+        raise RuntimeError(f"codex dialogue failed: {err.stderr}") from err
+
+    try:
+        return DialogueProposal.model_validate_json(completed.stdout.strip())
+    except ValidationError as parse_err:
+        raise ContractValidationError(
+            [
+                ValidationProblem(
+                    code="dialogue_malformed",
+                    message=str(parse_err)[:500],
+                    path="<dialogue>",
+                )
+            ]
+        ) from parse_err

--- a/automations/ln_voice_over_v2/stages/dialogue/chunking.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/chunking.py
@@ -1,0 +1,148 @@
+"""Chunk oversized dialogue attribution payloads and merge chunk proposals."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .agent import CandidateDecision, DialogueProposal
+from .context import ChapterPayload, PayloadSegment
+
+DEFAULT_MAX_CANDIDATES_PER_CHUNK = 300
+DEFAULT_CONTEXT_OVERLAP_SEGMENTS = 8
+
+
+def split_payload(
+    payload: ChapterPayload,
+    *,
+    max_candidates_per_chunk: int,
+    context_overlap_segments: int = DEFAULT_CONTEXT_OVERLAP_SEGMENTS,
+) -> list[ChapterPayload]:
+    """Split a chapter payload into contiguous candidate-capped chunks."""
+    if len(payload.candidate_ids) <= max_candidates_per_chunk:
+        return [payload]
+    if max_candidates_per_chunk < 1:
+        raise ValueError("max_candidates_per_chunk must be at least 1")
+    if context_overlap_segments < 0:
+        raise ValueError("context_overlap_segments must be non-negative")
+
+    windows: list[tuple[PayloadSegment, ...]] = []
+    current_window: list[PayloadSegment] = []
+    current_candidate_count = 0
+    for segment in payload.segments:
+        if segment.role == "candidate" and current_candidate_count >= max_candidates_per_chunk:
+            windows.append(tuple(current_window))
+            current_window = []
+            current_candidate_count = 0
+
+        current_window.append(segment)
+        if segment.role == "candidate":
+            current_candidate_count += 1
+
+    if current_window:
+        windows.append(tuple(current_window))
+
+    chunks: list[ChapterPayload] = []
+    previous_window: tuple[PayloadSegment, ...] = ()
+    for window in windows:
+        context_prefix = _context_prefix(previous_window, context_overlap_segments)
+        chunks.append(
+            ChapterPayload(
+                series=payload.series,
+                volume=payload.volume,
+                chapter_id=payload.chapter_id,
+                narrator_hint=payload.narrator_hint,
+                segments=(*context_prefix, *window),
+                candidate_ids=tuple(
+                    segment.segment_id for segment in window if segment.role == "candidate"
+                ),
+            )
+        )
+        previous_window = window
+    return chunks
+
+
+def merge_proposals(proposals: list[DialogueProposal]) -> DialogueProposal:
+    """Merge per-chunk dialogue proposals into one chapter-level proposal."""
+    decision_by_id: dict[str, CandidateDecision] = {}
+    conflict_notes: list[str] = []
+
+    for proposal in proposals:
+        for decision in proposal.decisions:
+            previous = decision_by_id.get(decision.segment_id)
+            if previous is None:
+                decision_by_id[decision.segment_id] = decision
+                continue
+
+            if (
+                previous.is_dialogue != decision.is_dialogue
+                or previous.speaker_raw != decision.speaker_raw
+            ):
+                conflict_notes.append(
+                    f"conflicting decisions across chunks for {decision.segment_id}; kept first"
+                )
+
+    notes = [note for proposal in proposals for note in proposal.review_notes]
+    notes.extend(conflict_notes)
+
+    return DialogueProposal(
+        decisions=tuple(decision_by_id.values()),
+        narrator_raw=_majority_narrator(proposals),
+        review_notes=tuple(dict.fromkeys(notes)),
+    )
+
+
+def attribute_with_chunking(
+    payload: ChapterPayload,
+    *,
+    attribute_chunk: Callable[[ChapterPayload], DialogueProposal],
+    max_candidates_per_chunk: int,
+    context_overlap_segments: int = DEFAULT_CONTEXT_OVERLAP_SEGMENTS,
+) -> DialogueProposal:
+    """Attribute a payload directly or by sequential chunk calls."""
+    chunks = split_payload(
+        payload,
+        max_candidates_per_chunk=max_candidates_per_chunk,
+        context_overlap_segments=context_overlap_segments,
+    )
+    if len(chunks) == 1:
+        return attribute_chunk(chunks[0])
+    return merge_proposals([attribute_chunk(chunk) for chunk in chunks])
+
+
+def _context_prefix(
+    previous_window: tuple[PayloadSegment, ...],
+    context_overlap_segments: int,
+) -> tuple[PayloadSegment, ...]:
+    """Return rebuilt lead-in context segments for the next chunk."""
+    if context_overlap_segments == 0:
+        return ()
+    return tuple(
+        PayloadSegment(
+            segment_id=segment.segment_id,
+            text=segment.text,
+            role="context",
+        )
+        for segment in previous_window[-context_overlap_segments:]
+    )
+
+
+def _majority_narrator(proposals: list[DialogueProposal]) -> str | None:
+    """Return the majority non-null narrator, with earliest chunk as tiebreaker."""
+    counts: dict[str, int] = {}
+    first_index: dict[str, int] = {}
+    for index, proposal in enumerate(proposals):
+        narrator = proposal.narrator_raw
+        if narrator is None:
+            continue
+        counts[narrator] = counts.get(narrator, 0) + 1
+        first_index.setdefault(narrator, index)
+
+    best: str | None = None
+    for narrator, count in counts.items():
+        if (
+            best is None
+            or count > counts[best]
+            or (count == counts[best] and first_index[narrator] < first_index[best])
+        ):
+            best = narrator
+    return best

--- a/automations/ln_voice_over_v2/stages/dialogue/config.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/config.py
@@ -1,0 +1,12 @@
+"""Dialogue-stage config loading helpers."""
+
+from __future__ import annotations
+
+from ...series.loader import load_character_registry
+from ..transform.chapters import load_story_profile, resolve_story_profile_path
+
+__all__ = [
+    "load_character_registry",
+    "load_story_profile",
+    "resolve_story_profile_path",
+]

--- a/automations/ln_voice_over_v2/stages/dialogue/context.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/context.py
@@ -1,0 +1,80 @@
+"""Pure context payload construction for dialogue attribution."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ...common.artifacts import ContractModel
+from ...common.ids import ChapterId, SegmentId, SeriesId, VolumeId
+from ...series.contracts import StoryProfile
+from ..transform.contracts import Segment, SegmentFile
+
+
+class PayloadSegment(ContractModel):
+    """One segment included in a chapter-level dialogue attribution payload."""
+
+    segment_id: SegmentId
+    text: str
+    role: Literal["candidate", "narration"]
+
+
+class ChapterPayload(ContractModel):
+    """Whole-chapter payload sent to the dialogue attribution boundary."""
+
+    series: SeriesId
+    volume: VolumeId
+    chapter_id: ChapterId
+    narrator_hint: str | None
+    segments: tuple[PayloadSegment, ...]
+    candidate_ids: tuple[SegmentId, ...]
+
+
+def select_candidates(segment_file: SegmentFile) -> tuple[Segment, ...]:
+    """Return quote-candidate segments in their existing chapter order.
+
+    Args:
+        segment_file: Chapter segment artifact to scan.
+
+    Returns:
+        Segments whose parser hints explicitly mark them as quote candidates.
+    """
+    return tuple(
+        segment
+        for segment in segment_file.segments
+        if segment.parser_hints.get("quote_candidate") is True
+    )
+
+
+def build_chapter_payload(
+    segment_file: SegmentFile, story_profile: StoryProfile | None = None
+) -> ChapterPayload:
+    """Build a whole-chapter dialogue payload without rewriting segment text.
+
+    Args:
+        segment_file: Chapter segment artifact to serialize.
+        story_profile: Optional story profile supplying a default narrator hint.
+
+    Returns:
+        Whole-chapter dialogue attribution payload.
+    """
+    candidate_ids = tuple(segment.segment_id for segment in select_candidates(segment_file))
+    candidate_id_set = set(candidate_ids)
+    narrator_hint = (
+        story_profile.rules.get("default_narrator") if story_profile is not None else None
+    )
+
+    return ChapterPayload(
+        series=segment_file.series,
+        volume=segment_file.volume,
+        chapter_id=segment_file.chapter_id,
+        narrator_hint=narrator_hint,
+        segments=tuple(
+            PayloadSegment(
+                segment_id=segment.segment_id,
+                text=segment.text,
+                role="candidate" if segment.segment_id in candidate_id_set else "narration",
+            )
+            for segment in segment_file.segments
+        ),
+        candidate_ids=candidate_ids,
+    )

--- a/automations/ln_voice_over_v2/stages/dialogue/context.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/context.py
@@ -15,7 +15,7 @@ class PayloadSegment(ContractModel):
 
     segment_id: SegmentId
     text: str
-    role: Literal["candidate", "narration"]
+    role: Literal["candidate", "narration", "context"]
 
 
 class ChapterPayload(ContractModel):

--- a/automations/ln_voice_over_v2/stages/dialogue/names.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/names.py
@@ -1,0 +1,55 @@
+"""Name normalization helpers for dialogue attribution."""
+
+from __future__ import annotations
+
+from ...pipeline.validators import UNKNOWN_SPEAKER
+from ...series.contracts import CharacterRegistry
+
+FIRST_PERSON_TAGS = frozenset({"i", "me", "myself", "i."})
+
+
+def canonical_speaker(
+    raw: str | None, registry: CharacterRegistry, narrator: str | None = None
+) -> str:
+    """Resolve a raw speaker label to a canonical character name or `Unknown`.
+
+    Args:
+        raw: Raw model-proposed speaker label.
+        registry: Series character registry used for exact name and alias lookup.
+        narrator: Already-canonical narrator name used for first-person tags.
+
+    Returns:
+        A canonical character name, the narrator for first-person labels when
+        provided, or `Unknown` when the label cannot be resolved.
+    """
+    if raw is None:
+        return UNKNOWN_SPEAKER
+
+    candidate = raw.strip()
+    if not candidate:
+        return UNKNOWN_SPEAKER
+
+    if candidate.casefold() in FIRST_PERSON_TAGS and narrator is not None:
+        return narrator
+
+    return registry.resolve(candidate) or UNKNOWN_SPEAKER
+
+
+def canonical_narrator(raw: str | None, registry: CharacterRegistry) -> str | None:
+    """Resolve a raw narrator label to a canonical character name when possible.
+
+    Args:
+        raw: Raw model-proposed narrator label.
+        registry: Series character registry used for exact name and alias lookup.
+
+    Returns:
+        Canonical narrator name when resolved; otherwise `None`.
+    """
+    if raw is None:
+        return None
+
+    candidate = raw.strip()
+    if not candidate:
+        return None
+
+    return registry.resolve(candidate)

--- a/automations/ln_voice_over_v2/stages/dialogue/prompts.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/prompts.py
@@ -1,0 +1,31 @@
+"""Prompt construction for LNVO dialogue attribution."""
+
+from .context import ChapterPayload
+
+DIALOGUE_PROMPT: str = """You are the dialogue attribution stage for light novel voice-over.
+
+Read the chapter payload and return STRICT JSON ONLY. Do not include markdown,
+comments, code fences, prose, or any text outside the JSON object.
+
+Return exactly this DialogueProposal shape:
+{"decisions":[{"segment_id":str,"is_dialogue":bool,"speaker_raw":str|null,"reason":str}],"narrator_raw":str|null,"review_notes":[str]}
+
+Rules:
+- Only classify segments whose role is "candidate".
+- Set is_dialogue=true only for true spoken dialogue.
+- Set is_dialogue=false for quoted narration, titles, labels, thoughts that are
+  not spoken aloud, sound effects, or other non-dialogue; include a short reason.
+- speaker_raw must be one of the provided roster names or aliases, otherwise null.
+- narrator_raw must be one of the provided roster names or aliases, otherwise null.
+- Never invent names, aliases, speakers, narrators, or segment IDs.
+- Use mechanical structured-attribution framing: base decisions on explicit
+  attribution, turn-taking, local context, and provided roster evidence.
+"""
+
+
+def build_prompt(payload: ChapterPayload, roster: tuple[str, ...]) -> str:
+    """Build the model prompt for dialogue attribution."""
+    roster_lines = "\n".join(f"- {name}" for name in roster)
+    roster_display = roster_lines if roster_lines else "- <empty>"
+    roster_block = f"\n\nRoster names and aliases:\n{roster_display}\n\nChapter payload JSON:\n"
+    return DIALOGUE_PROMPT + roster_block + payload.model_dump_json()

--- a/automations/ln_voice_over_v2/stages/dialogue/prompts.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/prompts.py
@@ -11,12 +11,17 @@ Return exactly this DialogueProposal shape:
 {"decisions":[{"segment_id":str,"is_dialogue":bool,"speaker_raw":str|null,"reason":str}],"narrator_raw":str|null,"review_notes":[str]}
 
 Rules:
-- Only classify segments whose role is "candidate".
+- Only classify segments whose role is "candidate". Segments with role
+  "narration" or "context" are background for turn-taking and continuity only;
+  never emit a decision for them.
 - Set is_dialogue=true only for true spoken dialogue.
 - Set is_dialogue=false for quoted narration, titles, labels, thoughts that are
   not spoken aloud, sound effects, or other non-dialogue; include a short reason.
 - speaker_raw must be one of the provided roster names or aliases, otherwise null.
 - narrator_raw must be one of the provided roster names or aliases, otherwise null.
+- If the payload includes a narrator_hint, treat it as the default narrator
+  unless explicit in-chapter evidence overrides it; still return narrator_raw as
+  a roster name/alias or null.
 - Never invent names, aliases, speakers, narrators, or segment IDs.
 - Use mechanical structured-attribution framing: base decisions on explicit
   attribution, turn-taking, local context, and provided roster evidence.

--- a/automations/ln_voice_over_v2/stages/dialogue/runner.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/runner.py
@@ -16,7 +16,11 @@ from ...common.json_io import load_json_contract, save_json_contract
 from ...pipeline.validators import UNKNOWN_SPEAKER, validate_dialogue_against_segments
 from ...series.contracts import CharacterRegistry
 from ..transform.contracts import SegmentFile, VolumeIndex
-from .agent import DialogueProposal, run_codex_dialogue
+from .agent import (
+    DEFAULT_DIALOGUE_TIMEOUT_SECONDS,
+    DialogueProposal,
+    run_codex_dialogue,
+)
 from .config import (
     load_character_registry,
     load_story_profile,
@@ -42,6 +46,7 @@ class DialogueConfig:
     chapter_id: ChapterId
     data_root: Path = paths.DEFAULT_PROJECT_DATA_ROOT
     force: bool = False
+    timeout_seconds: int = DEFAULT_DIALOGUE_TIMEOUT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -120,7 +125,10 @@ def run_dialogue(
     if attribute_fn is None:
 
         def attribute_fn(payload: ChapterPayload) -> DialogueProposal:
-            return run_codex_dialogue(build_prompt(payload, _roster(registry)))
+            return run_codex_dialogue(
+                build_prompt(payload, _roster(registry)),
+                timeout_seconds=config.timeout_seconds,
+            )
 
     proposal = attribute_fn(payload)
 
@@ -223,6 +231,7 @@ class DialogueVolumeConfig:
     data_root: Path = paths.DEFAULT_PROJECT_DATA_ROOT
     force: bool = False
     workers: int = 4
+    timeout_seconds: int = DEFAULT_DIALOGUE_TIMEOUT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -298,6 +307,7 @@ def run_dialogue_volume(
             chapter_id=chapter_id,
             data_root=config.data_root,
             force=config.force,
+            timeout_seconds=config.timeout_seconds,
         )
         # Each chapter is a separate external model call; isolate a per-chapter
         # failure so one bad chapter does not abort the rest of the volume.

--- a/automations/ln_voice_over_v2/stages/dialogue/runner.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -90,7 +91,10 @@ def run_dialogue(
             [
                 ValidationProblem(
                     code="unknown_chapter",
-                    message=f"Chapter {config.chapter_id} is not in volume index",
+                    message=(
+                        f"{config.chapter_id!r} is not in the volume index; "
+                        f"available: {', '.join(sorted(chapter_ids))}"
+                    ),
                     path="chapter_id",
                 )
             ]
@@ -208,6 +212,105 @@ def run_dialogue(
         review_required=review_required,
         skipped=False,
     )
+
+
+@dataclass(frozen=True)
+class DialogueVolumeConfig:
+    """Configuration for running dialogue attribution across a whole volume."""
+
+    series: SeriesId
+    volume: VolumeId
+    data_root: Path = paths.DEFAULT_PROJECT_DATA_ROOT
+    force: bool = False
+    workers: int = 4
+
+
+@dataclass(frozen=True)
+class ChapterOutcome:
+    """Outcome of one chapter within a volume dialogue run."""
+
+    chapter_id: ChapterId
+    result: DialogueResult | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class DialogueVolumeResult:
+    """Aggregate result of a volume dialogue run, in volume order."""
+
+    outcomes: tuple[ChapterOutcome, ...]
+
+    @property
+    def written(self) -> int:
+        """Return the number of chapters (re)generated this run."""
+        return sum(
+            1
+            for outcome in self.outcomes
+            if outcome.result is not None and not outcome.result.skipped
+        )
+
+    @property
+    def skipped(self) -> int:
+        """Return the number of chapters skipped because their file already existed."""
+        return sum(
+            1 for outcome in self.outcomes if outcome.result is not None and outcome.result.skipped
+        )
+
+    @property
+    def failed(self) -> int:
+        """Return the number of chapters that raised during attribution."""
+        return sum(1 for outcome in self.outcomes if outcome.error is not None)
+
+
+def run_dialogue_volume(
+    config: DialogueVolumeConfig,
+    *,
+    attribute_fn: AttributeFn | None = None,
+) -> DialogueVolumeResult:
+    """Run dialogue attribution for every chapter in a volume, in parallel.
+
+    Each chapter is processed by `run_dialogue`; an existing dialogue file is
+    skipped unless `config.force`. A per-chapter failure is isolated and
+    reported rather than aborting the whole volume.
+
+    Args:
+        config: Volume-level dialogue configuration.
+        attribute_fn: Optional attribution seam shared by every chapter.
+
+    Returns:
+        Per-chapter outcomes in volume order.
+    """
+    volume_index = load_json_contract(
+        paths.volume_index_path(config.data_root, config.series, config.volume),
+        VolumeIndex,
+    )
+    chapter_ids = [chapter.chapter_id for chapter in volume_index.chapters]
+    logger.info(
+        "dialogue: dispatching %d chapter(s) over %d worker(s)",
+        len(chapter_ids),
+        config.workers,
+    )
+
+    def _run_one(chapter_id: ChapterId) -> ChapterOutcome:
+        chapter_config = DialogueConfig(
+            series=config.series,
+            volume=config.volume,
+            chapter_id=chapter_id,
+            data_root=config.data_root,
+            force=config.force,
+        )
+        # Each chapter is a separate external model call; isolate a per-chapter
+        # failure so one bad chapter does not abort the rest of the volume.
+        try:
+            result = run_dialogue(chapter_config, attribute_fn=attribute_fn)
+        except Exception as exc:
+            logger.warning("dialogue: chapter %s failed: %s", chapter_id, exc)
+            return ChapterOutcome(chapter_id=chapter_id, error=str(exc))
+        return ChapterOutcome(chapter_id=chapter_id, result=result)
+
+    with ThreadPoolExecutor(max_workers=max(1, config.workers)) as executor:
+        outcomes = tuple(executor.map(_run_one, chapter_ids))
+    return DialogueVolumeResult(outcomes=outcomes)
 
 
 def _roster(registry: CharacterRegistry) -> tuple[str, ...]:

--- a/automations/ln_voice_over_v2/stages/dialogue/runner.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/runner.py
@@ -21,6 +21,7 @@ from .agent import (
     DialogueProposal,
     run_codex_dialogue,
 )
+from .chunking import DEFAULT_MAX_CANDIDATES_PER_CHUNK, attribute_with_chunking
 from .config import (
     load_character_registry,
     load_story_profile,
@@ -47,6 +48,7 @@ class DialogueConfig:
     data_root: Path = paths.DEFAULT_PROJECT_DATA_ROOT
     force: bool = False
     timeout_seconds: int = DEFAULT_DIALOGUE_TIMEOUT_SECONDS
+    max_candidates_per_chunk: int = DEFAULT_MAX_CANDIDATES_PER_CHUNK
 
 
 @dataclass(frozen=True)
@@ -123,11 +125,19 @@ def run_dialogue(
     candidate_id_set = set(candidate_ids)
 
     if attribute_fn is None:
+        roster = _roster(registry)
 
         def attribute_fn(payload: ChapterPayload) -> DialogueProposal:
-            return run_codex_dialogue(
-                build_prompt(payload, _roster(registry)),
-                timeout_seconds=config.timeout_seconds,
+            def attribute_chunk(chunk: ChapterPayload) -> DialogueProposal:
+                return run_codex_dialogue(
+                    build_prompt(chunk, roster),
+                    timeout_seconds=config.timeout_seconds,
+                )
+
+            return attribute_with_chunking(
+                payload,
+                attribute_chunk=attribute_chunk,
+                max_candidates_per_chunk=config.max_candidates_per_chunk,
             )
 
     proposal = attribute_fn(payload)
@@ -232,6 +242,7 @@ class DialogueVolumeConfig:
     force: bool = False
     workers: int = 4
     timeout_seconds: int = DEFAULT_DIALOGUE_TIMEOUT_SECONDS
+    max_candidates_per_chunk: int = DEFAULT_MAX_CANDIDATES_PER_CHUNK
 
 
 @dataclass(frozen=True)
@@ -308,6 +319,7 @@ def run_dialogue_volume(
             data_root=config.data_root,
             force=config.force,
             timeout_seconds=config.timeout_seconds,
+            max_candidates_per_chunk=config.max_candidates_per_chunk,
         )
         # Each chapter is a separate external model call; isolate a per-chapter
         # failure so one bad chapter does not abort the rest of the volume.

--- a/automations/ln_voice_over_v2/stages/dialogue/runner.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/runner.py
@@ -1,0 +1,220 @@
+"""Run dialogue attribution for a prepared chapter."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...common import paths
+from ...common.enums import PerspectiveStatus, ReviewStatus
+from ...common.errors import ContractValidationError, ValidationProblem
+from ...common.ids import ChapterId, SeriesId, VolumeId
+from ...common.json_io import load_json_contract, save_json_contract
+from ...pipeline.validators import UNKNOWN_SPEAKER, validate_dialogue_against_segments
+from ...series.contracts import CharacterRegistry
+from ..transform.contracts import SegmentFile, VolumeIndex
+from .agent import DialogueProposal, run_codex_dialogue
+from .config import (
+    load_character_registry,
+    load_story_profile,
+    resolve_story_profile_path,
+)
+from .context import ChapterPayload, build_chapter_payload
+from .contracts import DialogueChapter, DialogueRow, Perspective, RejectedCandidate
+from .names import canonical_narrator, canonical_speaker
+from .prompts import build_prompt
+from .validation import validate_dialogue_artifact
+
+logger = logging.getLogger("ln_voice_over_v2.dialogue.runner")
+
+AttributeFn = Callable[[ChapterPayload], DialogueProposal]
+
+
+@dataclass(frozen=True)
+class DialogueConfig:
+    """Configuration for running dialogue attribution on one chapter."""
+
+    series: SeriesId
+    volume: VolumeId
+    chapter_id: ChapterId
+    data_root: Path = paths.DEFAULT_PROJECT_DATA_ROOT
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class DialogueResult:
+    """Result of a dialogue attribution run."""
+
+    dialogue_path: Path
+    dialogue: DialogueChapter
+    accepted_count: int
+    rejected_count: int
+    review_required: bool
+    skipped: bool
+
+
+def run_dialogue(
+    config: DialogueConfig,
+    *,
+    attribute_fn: AttributeFn | None = None,
+) -> DialogueResult:
+    """Run dialogue attribution for one chapter and write the artifact."""
+
+    dialogue_path = paths.dialogue_chapter_path(
+        config.data_root,
+        config.series,
+        config.volume,
+        config.chapter_id,
+    )
+    if dialogue_path.exists() and not config.force:
+        logger.info("Dialogue artifact exists; skipping: %s", dialogue_path)
+        dialogue = load_json_contract(dialogue_path, DialogueChapter)
+        return DialogueResult(
+            dialogue_path=dialogue_path,
+            dialogue=dialogue,
+            accepted_count=len(dialogue.dialogues),
+            rejected_count=len(dialogue.rejected_candidates),
+            review_required=dialogue.review_required,
+            skipped=True,
+        )
+
+    volume_index = load_json_contract(
+        paths.volume_index_path(config.data_root, config.series, config.volume),
+        VolumeIndex,
+    )
+    chapter_ids = {chapter.chapter_id for chapter in volume_index.chapters}
+    if config.chapter_id not in chapter_ids:
+        raise ContractValidationError(
+            [
+                ValidationProblem(
+                    code="unknown_chapter",
+                    message=f"Chapter {config.chapter_id} is not in volume index",
+                    path="chapter_id",
+                )
+            ]
+        )
+
+    segment_file = load_json_contract(
+        paths.segment_file_path(
+            config.data_root,
+            config.series,
+            config.volume,
+            config.chapter_id,
+        ),
+        SegmentFile,
+    )
+    registry = load_character_registry(
+        paths.characters_config_path(config.data_root, config.series)
+    )
+    story_profile = load_story_profile(resolve_story_profile_path(config.data_root, config.series))
+    payload = build_chapter_payload(segment_file, story_profile)
+    candidate_ids = payload.candidate_ids
+    candidate_id_set = set(candidate_ids)
+
+    if attribute_fn is None:
+
+        def attribute_fn(payload: ChapterPayload) -> DialogueProposal:
+            return run_codex_dialogue(build_prompt(payload, _roster(registry)))
+
+    proposal = attribute_fn(payload)
+
+    segment_order = {
+        segment.segment_id: index for index, segment in enumerate(segment_file.segments)
+    }
+    all_segment_ids = set(segment_order)
+    decision_by_id = {}
+    stray_notes: list[str] = []
+    rejected: list[RejectedCandidate] = []
+    omitted_candidate = False
+
+    for decision in proposal.decisions:
+        if decision.segment_id in candidate_id_set:
+            decision_by_id[decision.segment_id] = decision
+        elif decision.segment_id in all_segment_ids:
+            rejected.append(
+                RejectedCandidate(
+                    segment_id=decision.segment_id,
+                    reason="model_stray_segment",
+                )
+            )
+        else:
+            stray_notes.append(f"stray segment {decision.segment_id} ignored")
+
+    narrator = canonical_narrator(proposal.narrator_raw, registry)
+    dialogues: list[DialogueRow] = []
+    for segment_id in candidate_ids:
+        decision = decision_by_id.get(segment_id)
+        if decision is None:
+            omitted_candidate = True
+            rejected.append(RejectedCandidate(segment_id=segment_id, reason="model_omitted"))
+        elif decision.is_dialogue:
+            dialogues.append(
+                DialogueRow(
+                    segment_id=segment_id,
+                    speaker=canonical_speaker(
+                        decision.speaker_raw,
+                        registry,
+                        narrator=narrator,
+                    ),
+                )
+            )
+        else:
+            rejected.append(
+                RejectedCandidate(
+                    segment_id=segment_id,
+                    reason=decision.reason or "rejected",
+                )
+            )
+
+    review_notes = tuple((*proposal.review_notes, *stray_notes))
+    review_required = (
+        any(row.speaker == UNKNOWN_SPEAKER for row in dialogues)
+        or narrator is None
+        or omitted_candidate
+        or bool(review_notes)
+    )
+    status = ReviewStatus.NEEDS_REVIEW if review_required else ReviewStatus.ACCEPTED
+    perspective = Perspective(
+        status=(PerspectiveStatus.DETECTED if narrator is not None else PerspectiveStatus.UNSET),
+        narrator=narrator,
+    )
+
+    dialogues.sort(key=lambda row: segment_order[row.segment_id])
+    rejected.sort(key=lambda row: segment_order[row.segment_id])
+
+    dialogue = DialogueChapter(
+        series=config.series,
+        volume=config.volume,
+        chapter_id=config.chapter_id,
+        status=status,
+        review_required=review_required,
+        perspective=perspective,
+        dialogues=tuple(dialogues),
+        rejected_candidates=tuple(rejected),
+        review_notes=review_notes,
+    )
+
+    validate_dialogue_artifact(dialogue, candidate_ids)
+    validate_dialogue_against_segments(dialogue, segment_file, registry)
+    save_json_contract(dialogue_path, dialogue)
+
+    return DialogueResult(
+        dialogue_path=dialogue_path,
+        dialogue=dialogue,
+        accepted_count=len(dialogues),
+        rejected_count=len(rejected),
+        review_required=review_required,
+        skipped=False,
+    )
+
+
+def _roster(registry: CharacterRegistry) -> tuple[str, ...]:
+    """Return the character names the attribution prompt may use."""
+
+    names: list[str] = []
+    for character in registry.characters:
+        names.append(character.name)
+        names.extend(character.aliases)
+    return tuple(names)

--- a/automations/ln_voice_over_v2/stages/dialogue/validation.py
+++ b/automations/ln_voice_over_v2/stages/dialogue/validation.py
@@ -1,0 +1,47 @@
+"""Validation for dialogue-stage artifacts."""
+
+from ...common.enums import ReviewStatus
+from ...common.errors import ContractValidationError, ValidationProblem
+from ...common.ids import SegmentId
+from .contracts import DialogueChapter
+
+
+def validate_dialogue_artifact(
+    dialogue: DialogueChapter, candidate_ids: tuple[SegmentId, ...]
+) -> None:
+    """Validate dialogue-stage coverage and review status consistency."""
+    problems: list[ValidationProblem] = []
+    dialogue_ids = {row.segment_id for row in dialogue.dialogues}
+    rejected_ids = {candidate.segment_id for candidate in dialogue.rejected_candidates}
+    candidate_id_set = set(candidate_ids)
+
+    for segment_id in sorted(candidate_id_set - (dialogue_ids | rejected_ids)):
+        problems.append(
+            ValidationProblem(
+                code="uncovered_candidate",
+                message=f"Candidate segment is not covered: {segment_id}",
+                path=f"candidates.{segment_id}",
+            )
+        )
+
+    for segment_id in sorted(dialogue_ids & rejected_ids):
+        problems.append(
+            ValidationProblem(
+                code="candidate_in_both",
+                message=f"Candidate segment appears in dialogue and rejected lists: {segment_id}",
+                path=f"dialogue.{segment_id}",
+            )
+        )
+
+    needs_review = dialogue.status == ReviewStatus.NEEDS_REVIEW
+    if needs_review != dialogue.review_required:
+        problems.append(
+            ValidationProblem(
+                code="status_mismatch",
+                message="Dialogue status must match review_required",
+                path="status",
+            )
+        )
+
+    if problems:
+        raise ContractValidationError(problems)

--- a/docs/lnvo/02-transform.md
+++ b/docs/lnvo/02-transform.md
@@ -2,9 +2,9 @@ Transform converts a prepared volume into stable chapter segment files.
 
 ## Purpose
 
-| Output | Contract |
-| --- | --- |
-| Volume index | `<volume>/volume_index.json` orders chapter segment files. |
+| Output        | Contract                                                            |
+| ------------- | ------------------------------------------------------------------- |
+| Volume index  | `<volume>/volume_index.json` orders chapter segment files.          |
 | Segment files | `<volume>/segments/chapter_XX[_M].json` store stable text segments. |
 
 Sufficient handoff: Dialogue and Scenes can reference text through `segment_id`.

--- a/docs/lnvo/03-dialogue.md
+++ b/docs/lnvo/03-dialogue.md
@@ -70,3 +70,79 @@ Review edits update this file directly until `status: accepted`.
 - every speaker is canonical or `Unknown`;
 - detected `perspective.narrator` is canonical or `null`;
 - downstream stages require `status: accepted`.
+
+Two validators run before any write (mirroring transform): a stage-local
+`validate_dialogue_artifact` and the cross-artifact
+`validate_dialogue_against_segments`.
+
+| Validator | Checks |
+| --- | --- |
+| stage-local (`stages/dialogue/validation.py`) | every `quote_candidate` segment is classified into `dialogues` xor `rejected_candidates` (`uncovered_candidate`); no id in both (`candidate_in_both`); `status == needs_review` iff `review_required` (`status_mismatch`). |
+| cross-artifact (`pipeline/validators.py`) | `segment_id` resolution, no duplicate dialogue segment, speaker canonical-or-`Unknown`, detected narrator canonical-or-`null`. |
+
+## CLI
+
+```text
+python -m automations.ln_voice_over_v2.stages.dialogue \
+  --series <series> --volume <volume> --chapter <chapter_id> [--data-root DIR] [--force]
+```
+
+Prints the written dialogue path on success (exit 0). A
+`ContractValidationError` prints each problem and exits 2; other errors exit 1.
+
+## Implementation Notes
+
+Unlike transform, dialogue is **not** byte-deterministic: it makes one LLM call
+per chapter. Idempotency comes from skip-existing plus validate-before-write,
+not reproducibility.
+
+### Model boundary
+
+The model proposes; the runner decides. `stages/dialogue/agent.py::run_codex_dialogue`
+mirrors the prepare-stage `run_codex_ocr` boundary (a `codex exec` subprocess with
+`--ignore-user-config --ephemeral --skip-git-repo-check -s read-only`, strict JSON
+parse, `RuntimeError` on non-zero exit, `ContractValidationError` on malformed
+output) but is text-only (no `-i` image flag). The chapter payload and character
+roster are built by `prompts.build_prompt` and appended to the prompt. The model
+returns only an internal `DialogueProposal` (per-candidate `is_dialogue` /
+`speaker_raw` / `reason`, plus `narrator_raw` and `review_notes`); it never emits
+the persisted `DialogueChapter`. The runner accepts an injectable `attribute_fn`
+seam so tests never spawn `codex`.
+
+### Assembly and review state
+
+The runner restricts decisions to the chapter's `quote_candidate` segments and
+assembles rows in segment order:
+
+- a candidate the model omitted becomes `RejectedCandidate(reason="model_omitted")`;
+- a non-candidate id the model returned becomes `RejectedCandidate(reason="model_stray_segment")` when it resolves to a real segment, otherwise it is dropped with a review note;
+- accepted candidates become `DialogueRow`s with a canonicalized speaker.
+
+`review_required` is computed from the **canonicalized** speakers and is `true`
+when any accepted speaker is `Unknown`, the narrator is unresolved, a candidate
+was omitted, or any review note exists. `status` is `needs_review` iff
+`review_required`, else `accepted`.
+
+### Name normalization
+
+Speaker and narrator labels resolve through `CharacterRegistry.resolve` (exact
+canonical name or alias match, **no fuzzy matching**). A first-person speaker tag
+(`I`/`me`/...) resolves through the chapter narrator. Unresolved speakers become
+`Unknown`; unresolved narrators become `null`. No invented characters.
+
+### Inputs and config
+
+`config/characters.json` is **required and has no packaged fallback** (character
+lists are series content); a missing file raises before any model call.
+`config/story_profile.json` is optional context (its `rules.default_narrator`
+seeds a narrator hint) and resolves via the shared transform resolver.
+
+### Reviewer safety
+
+The dialogue JSON is the working review file. A re-run **skips** an existing file
+unless `--force`; validate-before-write means a bad run never corrupts an existing
+good file.
+
+## Design History
+
+- **2026-05-30 — Stage 3 designed via ralplan consensus and implemented by Codex agents** (`.omc/plans/lnvo-v2-dialogue-stage3.md`). Architect raised a blocker: v2 `CharacterRegistry` had only `has_character` (exact, no aliases), so alias normalization had no backing code. Resolved by user decision **R1** — added an additive `CharacterRegistry.resolve(name) -> str | None` (exact name + alias, no fuzzy). Other consensus refinements folded in: model proposes an internal `DialogueProposal` (runner assembles the trusted artifact); per-chapter single call (Option A; per-candidate Option B deferred); omitted/stray candidates become explicit `RejectedCandidate`s; rows sorted by segment order; skip-existing unless `--force`; series-shared `load_character_registry`.

--- a/docs/lnvo/03-dialogue.md
+++ b/docs/lnvo/03-dialogue.md
@@ -83,12 +83,27 @@ Two validators run before any write (mirroring transform): a stage-local
 ## CLI
 
 ```text
+# whole volume (default): attribute every chapter in volume_index.json
+python -m automations.ln_voice_over_v2.stages.dialogue \
+  --series <series> --volume <volume> [--workers N] [--data-root DIR] [--force]
+
+# one chapter
 python -m automations.ln_voice_over_v2.stages.dialogue \
   --series <series> --volume <volume> --chapter <chapter_id> [--data-root DIR] [--force]
 ```
 
-Prints the written dialogue path on success (exit 0). A
-`ContractValidationError` prints each problem and exits 2; other errors exit 1.
+`--chapter` is optional. Omit it to run the whole volume, dispatching `--workers`
+chapters concurrently (default 4); each chapter is a separate `codex` call.
+Chapter ids come from `volume_index.json` (`chapter_01`, `chapter_07_1`,
+`chapter_00` for front matter); you do not need to know them for a whole-volume
+run, and an unknown `--chapter` error lists the available ids.
+
+Single-chapter mode prints the written dialogue path (exit 0). Whole-volume mode
+prints one line per chapter (path, `skipped (exists)`, or `error: …`) and a
+`written / skipped / failed` summary, exiting 1 if any chapter failed. In both
+modes a `ContractValidationError` prints each problem and exits 2. Existing
+dialogue files are skipped unless `--force`, so a whole-volume re-run only fills
+in missing chapters and never clobbers reviewed ones.
 
 ## Implementation Notes
 

--- a/docs/lnvo/03-dialogue.md
+++ b/docs/lnvo/03-dialogue.md
@@ -85,15 +85,18 @@ Two validators run before any write (mirroring transform): a stage-local
 ```text
 # whole volume (default): attribute every chapter in volume_index.json
 python -m automations.ln_voice_over_v2.stages.dialogue \
-  --series <series> --volume <volume> [--workers N] [--data-root DIR] [--force]
+  --series <series> --volume <volume> [--workers N] [--timeout SECONDS] [--data-root DIR] [--force]
 
 # one chapter
 python -m automations.ln_voice_over_v2.stages.dialogue \
-  --series <series> --volume <volume> --chapter <chapter_id> [--data-root DIR] [--force]
+  --series <series> --volume <volume> --chapter <chapter_id> [--timeout SECONDS] [--data-root DIR] [--force]
 ```
 
 `--chapter` is optional. Omit it to run the whole volume, dispatching `--workers`
 chapters concurrently (default 4); each chapter is a separate `codex` call.
+`--timeout` bounds that single per-chapter `codex` call in seconds (default
+600); raise it for unusually long chapters that otherwise time out, or lower it
+to fail fast.
 Chapter ids come from `volume_index.json` (`chapter_01`, `chapter_07_1`,
 `chapter_00` for front matter); you do not need to know them for a whole-volume
 run, and an unknown `--chapter` error lists the available ids.
@@ -157,6 +160,46 @@ seeds a narrator hint) and resolves via the shared transform resolver.
 The dialogue JSON is the working review file. A re-run **skips** an existing file
 unless `--force`; validate-before-write means a bad run never corrupts an existing
 good file.
+
+## Debugging & Known Issues
+
+Branch: `feat/lnvo-v2-dialogue-stage3` (implemented 2026-05-30; not merged/pushed).
+Model boundary: `gpt-5.5` via `codex exec` (text-only, strict JSON).
+
+### Where to look
+- **The artifact is the review file.** Open `<volume>/dialogue/<chapter>.json`:
+  `status` (`accepted`/`needs_review`), `review_required`, `perspective`,
+  `dialogues[]`, `rejected_candidates[]` (with `reason`), `review_notes[]`.
+- **Reject reasons** are diagnostic: `model_omitted` (model returned no decision
+  for a candidate), `model_stray_segment` (model classified a non-candidate),
+  or the model's own free-text reason for a genuine reject.
+- **`Unknown` speaker or `null` narrator** means `CharacterRegistry.resolve`
+  found no exact name/alias — fix `config/characters.json`, not the code.
+- **Model call:** `stages/dialogue/agent.py::run_codex_dialogue`; prompt in
+  `prompts.py`. A refusal / malformed JSON raises `ContractValidationError`
+  (`dialogue_malformed`); a non-zero `codex` exit or a per-chapter timeout
+  (default 600s, override with `--timeout`) raises `RuntimeError`. To inspect a
+  single chapter, run with `--chapter <id>` and read stderr.
+- Stage 3 is **not** byte-deterministic; idempotency is skip-existing + `--force`.
+
+### Known open issues (from code review — NOT yet fixed)
+1. **Silent duplicate-decision drop.** Two model decisions for the same candidate
+   collapse last-wins with no review flag (`runner.py`, `decision_by_id`).
+   Contradictory output is accepted clean instead of flagged.
+2. **`narrator_hint` is dead context.** `build_chapter_payload` puts
+   `story_profile.rules.default_narrator` into the payload, but `DIALOGUE_PROMPT`
+   never tells the model to use it — weakens narrator detection.
+3. **First-person precedence.** `names.canonical_speaker` resolves `I`/`me`
+   through the narrator *before* the registry lookup, so a character literally
+   named `I`/`me` would be shadowed (low likelihood, but reversed precedence).
+
+### Orchestration gotchas (when fixing via the `codex` CLI)
+- Use `codex exec --sandbox workspace-write` for writes; `resume` defaults to
+  read-only (override with `-c sandbox_mode=workspace-write`).
+- The PostToolUse `ruff --fix` hook strips a just-added import if its first use
+  lands in a *later* edit — add the import and its usage in the same change.
+- `codex exec` sometimes ends a turn after narrating intent without applying
+  patches; re-run or resume, and verify with `ruff` + `pytest` yourself.
 
 ## Design History
 

--- a/docs/lnvo/03-dialogue.md
+++ b/docs/lnvo/03-dialogue.md
@@ -85,18 +85,22 @@ Two validators run before any write (mirroring transform): a stage-local
 ```text
 # whole volume (default): attribute every chapter in volume_index.json
 python -m automations.ln_voice_over_v2.stages.dialogue \
-  --series <series> --volume <volume> [--workers N] [--timeout SECONDS] [--data-root DIR] [--force]
+  --series <series> --volume <volume> [--workers N] [--timeout SECONDS] \
+  [--max-candidates-per-chunk N] [--data-root DIR] [--force]
 
 # one chapter
 python -m automations.ln_voice_over_v2.stages.dialogue \
-  --series <series> --volume <volume> --chapter <chapter_id> [--timeout SECONDS] [--data-root DIR] [--force]
+  --series <series> --volume <volume> --chapter <chapter_id> [--timeout SECONDS] \
+  [--max-candidates-per-chunk N] [--data-root DIR] [--force]
 ```
 
 `--chapter` is optional. Omit it to run the whole volume, dispatching `--workers`
-chapters concurrently (default 4); each chapter is a separate `codex` call.
-`--timeout` bounds that single per-chapter `codex` call in seconds (default
-600); raise it for unusually long chapters that otherwise time out, or lower it
-to fail fast.
+chapters concurrently (default 4); each chapter is attributed independently.
+`--timeout` bounds each `codex` attribution call in seconds (default 600); raise
+it for unusually long chunks that otherwise time out, or lower it to fail fast.
+`--max-candidates-per-chunk N` chunks a chapter whose candidate count exceeds
+the integer cap (default 300); each chunk is a separate `codex` call and the
+partial proposals are merged before assembly.
 Chapter ids come from `volume_index.json` (`chapter_01`, `chapter_07_1`,
 `chapter_00` for front matter); you do not need to know them for a whole-volume
 run, and an unknown `--chapter` error lists the available ids.
@@ -110,9 +114,9 @@ in missing chapters and never clobbers reviewed ones.
 
 ## Implementation Notes
 
-Unlike transform, dialogue is **not** byte-deterministic: it makes one LLM call
-per chapter. Idempotency comes from skip-existing plus validate-before-write,
-not reproducibility.
+Unlike transform, dialogue is **not** byte-deterministic: it makes one or more
+LLM calls per chapter. Idempotency comes from skip-existing plus
+validate-before-write, not reproducibility.
 
 ### Model boundary
 
@@ -126,6 +130,26 @@ returns only an internal `DialogueProposal` (per-candidate `is_dialogue` /
 `speaker_raw` / `reason`, plus `narrator_raw` and `review_notes`); it never emits
 the persisted `DialogueChapter`. The runner accepts an injectable `attribute_fn`
 seam so tests never spawn `codex`.
+
+### Chunking
+
+Most chapters use one attribution call. Chunking triggers only when the chapter
+has more candidates than `max_candidates_per_chunk` (default 300). Oversized
+chapters are split into contiguous segment windows with at most that many owned
+candidates per window; each window keeps the surrounding narration needed to
+read those candidates in context.
+
+Each window after the first carries a small lead-in overlap from the previous
+window. Those carried segments use the payload role `"context"`, which is
+background only: the prompt tells the model not to classify `"context"` segments.
+Every window is attributed in its own `codex` call, then the partial
+`DialogueProposal`s are merged into one proposal before the existing assembly
+step runs.
+
+The merge is conservative: first-seen wins per `segment_id`; identical duplicate
+decisions are ignored; conflicting cross-chunk decisions keep the first decision
+and add a `review_notes` entry naming the segment. `narrator_raw` is resolved by
+majority vote across chunks.
 
 ### Assembly and review state
 
@@ -177,19 +201,19 @@ Model boundary: `gpt-5.5` via `codex exec` (text-only, strict JSON).
   found no exact name/alias — fix `config/characters.json`, not the code.
 - **Model call:** `stages/dialogue/agent.py::run_codex_dialogue`; prompt in
   `prompts.py`. A refusal / malformed JSON raises `ContractValidationError`
-  (`dialogue_malformed`); a non-zero `codex` exit or a per-chapter timeout
+  (`dialogue_malformed`); a non-zero `codex` exit or a per-call timeout
   (default 600s, override with `--timeout`) raises `RuntimeError`. To inspect a
   single chapter, run with `--chapter <id>` and read stderr.
 - Stage 3 is **not** byte-deterministic; idempotency is skip-existing + `--force`.
 
-### Known open issues (from code review — NOT yet fixed)
-1. **Silent duplicate-decision drop.** Two model decisions for the same candidate
-   collapse last-wins with no review flag (`runner.py`, `decision_by_id`).
-   Contradictory output is accepted clean instead of flagged.
-2. **`narrator_hint` is dead context.** `build_chapter_payload` puts
-   `story_profile.rules.default_narrator` into the payload, but `DIALOGUE_PROMPT`
-   never tells the model to use it — weakens narrator detection.
-3. **First-person precedence.** `names.canonical_speaker` resolves `I`/`me`
+### Known issues (from code review)
+1. **Resolved — duplicate-decision conflicts are flagged.** Cross-chunk merge
+   keeps the first decision for a segment and adds a `review_notes` entry when a
+   later chunk disagrees, so contradictory output is no longer silently dropped.
+2. **Resolved — `narrator_hint` is consumed by the prompt.** `DIALOGUE_PROMPT`
+   treats `story_profile.rules.default_narrator` as the default narrator unless
+   in-chapter evidence overrides it.
+3. **Open — first-person precedence.** `names.canonical_speaker` resolves `I`/`me`
    through the narrator *before* the registry lookup, so a character literally
    named `I`/`me` would be shadowed (low likelihood, but reversed precedence).
 
@@ -203,4 +227,5 @@ Model boundary: `gpt-5.5` via `codex exec` (text-only, strict JSON).
 
 ## Design History
 
-- **2026-05-30 — Stage 3 designed via ralplan consensus and implemented by Codex agents** (`.omc/plans/lnvo-v2-dialogue-stage3.md`). Architect raised a blocker: v2 `CharacterRegistry` had only `has_character` (exact, no aliases), so alias normalization had no backing code. Resolved by user decision **R1** — added an additive `CharacterRegistry.resolve(name) -> str | None` (exact name + alias, no fuzzy). Other consensus refinements folded in: model proposes an internal `DialogueProposal` (runner assembles the trusted artifact); per-chapter single call (Option A; per-candidate Option B deferred); omitted/stray candidates become explicit `RejectedCandidate`s; rows sorted by segment order; skip-existing unless `--force`; series-shared `load_character_registry`.
+- **2026-05-30 — Stage 3 designed via ralplan consensus and implemented by Codex agents** (`.omc/plans/lnvo-v2-dialogue-stage3.md`). Architect raised a blocker: v2 `CharacterRegistry` had only `has_character` (exact, no aliases), so alias normalization had no backing code. Resolved by user decision **R1** — added an additive `CharacterRegistry.resolve(name) -> str | None` (exact name + alias, no fuzzy). Other consensus refinements folded in: model proposes an internal `DialogueProposal` (runner assembles the trusted artifact); normal chapters use a per-chapter single call (Option A; per-candidate Option B deferred); omitted/stray candidates become explicit `RejectedCandidate`s; rows sorted by segment order; skip-existing unless `--force`; series-shared `load_character_registry`.
+- **2026-05-30 — Oversized dialogue chapters chunked** (`.omc/plans/lnvo-v2-dialogue-chunking.md`). Added `max_candidates_per_chunk` (default 300), lead-in `"context"` overlap, per-chunk `codex` calls, and merge-before-assembly semantics. This also resolved duplicate-decision conflict visibility and `narrator_hint` prompt usage.

--- a/docs/lnvo/runbook.md
+++ b/docs/lnvo/runbook.md
@@ -107,8 +107,8 @@ The override file shares the `StoryProfile` shape; only `rules.chapter_headings`
 ## Stage 3 — dialogue
 
 Detects spoken dialogue, assigns speakers, and resolves chapter perspective via
-one `codex` attribution call per chapter. The model proposes; the runner
-canonicalises names and writes the artifact.
+one or more `codex` attribution calls per chapter. The model proposes; the
+runner canonicalises names and writes the artifact.
 
 Prerequisite: Stage 2 produced `volume_index.json` + `segments/`, and
 `<data_root>/<series>/config/characters.json` exists (**required, no fallback** —
@@ -121,13 +121,17 @@ Canonical invocation:
 python -m automations.ln_voice_over_v2.stages.dialogue \
     --series classroom-of-the-elite-year-2 \
     --volume v4 \
-    --workers 4
+    --workers 4 \
+    --timeout 600 \
+    --max-candidates-per-chunk 300
 
 # single chapter
 python -m automations.ln_voice_over_v2.stages.dialogue \
     --series classroom-of-the-elite-year-2 \
     --volume v4 \
-    --chapter chapter_01
+    --chapter chapter_01 \
+    --timeout 600 \
+    --max-candidates-per-chunk 300
 ```
 
 Notes:
@@ -135,9 +139,12 @@ Notes:
 - `--chapter` is optional; omit it to run every chapter, `--workers` at a time
   (default 4). Chapter ids are `chapter_01`, `chapter_07_1`, `chapter_00`
   (front matter) — not bare numbers. An unknown `--chapter` lists the valid ids.
-- `--timeout SECONDS` bounds each chapter's single `codex` call (default 600). A
-  long chapter that reports `codex dialogue timed out after <N>s` just needs a
-  higher `--timeout`; a re-run re-attempts only the missing chapters.
+- `--timeout SECONDS` bounds each `codex` attribution call (default 600). A long
+  chunk that reports `codex dialogue timed out after <N>s` just needs a higher
+  `--timeout`; a re-run re-attempts only the missing chapters.
+- `--max-candidates-per-chunk N` chunks a chapter whose candidate count exceeds
+  the integer cap (default 300). Each chunk is a separate `codex` call and the
+  partial proposals are merged before assembly.
 - Existing `dialogue/<chapter>.json` files are **skipped unless `--force`** (the
   file is the working review surface; a re-run only fills missing chapters).
 - Whole-volume mode prints per-chapter lines + a `written / skipped / failed`

--- a/docs/lnvo/runbook.md
+++ b/docs/lnvo/runbook.md
@@ -2,7 +2,7 @@ Runbook collects the commands that produce real artifacts at each functional sta
 
 Run them in order; each stage reads what the previous stage wrote.
 
-Stages 3 (dialogue), 4 (scenes), and 5 (generation) are not yet runnable — contracts exist but no runner is wired. Only Stages 1 and 2 produce artifacts today.
+Stages 1, 2, and 3 (dialogue) are runnable today. Stages 4 (scenes) and 5 (generation) are not yet wired — contracts exist but no runner.
 
 ## Defaults
 
@@ -104,6 +104,67 @@ cp automations/ln_voice_over_v2/series/templates/story_profile.default.json \
 
 The override file shares the `StoryProfile` shape; only `rules.chapter_headings` (list of Python regex strings) and `rules.subchapters` (bool) are read by Stage 2 today.
 
-## Stages 3-5
+## Stage 3 — dialogue
 
-Not yet implemented. The contracts live at `automations/ln_voice_over_v2/stages/{dialogue,scenes,generation}/contracts.py`. Adding a runner is the next pipeline slice.
+Detects spoken dialogue, assigns speakers, and resolves chapter perspective via
+one `codex` attribution call per chapter. The model proposes; the runner
+canonicalises names and writes the artifact.
+
+Prerequisite: Stage 2 produced `volume_index.json` + `segments/`, and
+`<data_root>/<series>/config/characters.json` exists (**required, no fallback** —
+canonical character names + aliases). `codex` CLI signed in.
+
+Canonical invocation:
+
+```bash
+# whole volume (default): every chapter in volume_index.json
+python -m automations.ln_voice_over_v2.stages.dialogue \
+    --series classroom-of-the-elite-year-2 \
+    --volume v4 \
+    --workers 4
+
+# single chapter
+python -m automations.ln_voice_over_v2.stages.dialogue \
+    --series classroom-of-the-elite-year-2 \
+    --volume v4 \
+    --chapter chapter_01
+```
+
+Notes:
+
+- `--chapter` is optional; omit it to run every chapter, `--workers` at a time
+  (default 4). Chapter ids are `chapter_01`, `chapter_07_1`, `chapter_00`
+  (front matter) — not bare numbers. An unknown `--chapter` lists the valid ids.
+- `--timeout SECONDS` bounds each chapter's single `codex` call (default 600). A
+  long chapter that reports `codex dialogue timed out after <N>s` just needs a
+  higher `--timeout`; a re-run re-attempts only the missing chapters.
+- Existing `dialogue/<chapter>.json` files are **skipped unless `--force`** (the
+  file is the working review surface; a re-run only fills missing chapters).
+- Whole-volume mode prints per-chapter lines + a `written / skipped / failed`
+  summary and exits 1 if any chapter failed; per-chapter failures are isolated.
+
+Outputs:
+
+```text
+~/.assistant/ln_voice_over_v2/projects/<series>/<volume>/
+└── dialogue/
+    ├── chapter_00.json
+    ├── chapter_01.json
+    └── ...
+```
+
+See `docs/lnvo/03-dialogue.md` for the contract, review semantics
+(`status` / `review_required` / `rejected_candidates` reasons), and the
+"Debugging & Known Issues" section.
+
+Smoke-test:
+
+```bash
+pytest tests/automations/ln_voice_over_v2/stages/dialogue/ -q
+```
+
+## Stages 4-5
+
+Not yet implemented. The contracts live at
+`automations/ln_voice_over_v2/stages/{scenes,generation}/contracts.py`. Adding a
+runner is the next pipeline slice.

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/__init__.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/__init__.py
@@ -1,0 +1,1 @@
+"""Dialogue stage tests."""

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_agent.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_agent.py
@@ -84,8 +84,36 @@ def test_run_codex_dialogue_process_failure_raises_runtime_error(monkeypatch):
         fake_run,
     )
 
-    with pytest.raises(RuntimeError, match="codex dialogue failed: boom"):
-        run_codex_dialogue("prompt")
+    with pytest.raises(RuntimeError, match="codex dialogue failed: boom") as exc_info:
+        run_codex_dialogue("secret-prompt-text")
+
+    # The prompt-bearing CalledProcessError is suppressed from the chain
+    # (`from None`), so a printed traceback cannot surface argv via __cause__.cmd.
+    err = exc_info.value
+    assert "secret-prompt-text" not in str(err)
+    assert err.__cause__ is None
+    assert err.__suppress_context__ is True
+
+
+def test_run_codex_dialogue_timeout_raises_clean_runtime_error(monkeypatch):
+    def fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.agent.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        run_codex_dialogue("secret-prompt-text", timeout_seconds=5)
+
+    err = exc_info.value
+    assert "timed out after 5s" in str(err)
+    # Prompt must not leak: message is clean and the prompt-bearing TimeoutExpired
+    # (whose `cmd` is the full argv) is suppressed from the chain (`from None`).
+    assert "secret-prompt-text" not in str(err)
+    assert err.__cause__ is None
+    assert err.__suppress_context__ is True
 
 
 def test_build_prompt_includes_roster_and_payload_json():

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_agent.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_agent.py
@@ -1,0 +1,111 @@
+"""Tests for the dialogue Codex agent and prompt builder."""
+
+import subprocess
+
+import pytest
+from automations.ln_voice_over_v2.common.errors import ContractValidationError
+from automations.ln_voice_over_v2.stages.dialogue.agent import (
+    DialogueProposal,
+    run_codex_dialogue,
+)
+from automations.ln_voice_over_v2.stages.dialogue.context import (
+    ChapterPayload,
+    PayloadSegment,
+)
+from automations.ln_voice_over_v2.stages.dialogue.prompts import build_prompt
+
+
+def test_run_codex_dialogue_uses_text_only_argv(monkeypatch):
+    prompt = "classify this"
+    expected = (
+        '{"decisions":[{"segment_id":"seg_000001","is_dialogue":true,'
+        '"speaker_raw":"Ann","reason":"spoken"}],"narrator_raw":null,'
+        '"review_notes":[]}'
+    )
+
+    def fake_run(argv, **kwargs):
+        assert argv == [
+            "codex-bin",
+            "exec",
+            "-m",
+            "test-model",
+            "--ephemeral",
+            "--skip-git-repo-check",
+            "--ignore-user-config",
+            "-s",
+            "read-only",
+            prompt,
+        ]
+        assert "-i" not in argv
+        assert kwargs == {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.PIPE,
+            "text": True,
+            "timeout": 12,
+            "check": True,
+        }
+        return subprocess.CompletedProcess(argv, 0, stdout=expected, stderr="")
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.agent.subprocess.run",
+        fake_run,
+    )
+
+    proposal = run_codex_dialogue(
+        prompt,
+        model="test-model",
+        executable="codex-bin",
+        timeout_seconds=12,
+    )
+
+    assert isinstance(proposal, DialogueProposal)
+    assert proposal.decisions[0].segment_id == "seg_000001"
+    assert proposal.decisions[0].speaker_raw == "Ann"
+
+
+def test_run_codex_dialogue_malformed_stdout_raises_contract_error(monkeypatch):
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.agent.subprocess.run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout="not json", stderr=""),
+    )
+
+    with pytest.raises(ContractValidationError) as exc_info:
+        run_codex_dialogue("prompt")
+
+    assert [problem.code for problem in exc_info.value.problems] == ["dialogue_malformed"]
+
+
+def test_run_codex_dialogue_process_failure_raises_runtime_error(monkeypatch):
+    def fake_run(argv, **kwargs):
+        raise subprocess.CalledProcessError(1, argv, stderr="boom")
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.agent.subprocess.run",
+        fake_run,
+    )
+
+    with pytest.raises(RuntimeError, match="codex dialogue failed: boom"):
+        run_codex_dialogue("prompt")
+
+
+def test_build_prompt_includes_roster_and_payload_json():
+    payload = ChapterPayload(
+        series="series-1",
+        volume="volume-1",
+        chapter_id="chapter_01",
+        narrator_hint=None,
+        segments=(
+            PayloadSegment(
+                segment_id="seg_000001",
+                text='"Hello."',
+                role="candidate",
+            ),
+        ),
+        candidate_ids=("seg_000001",),
+    )
+
+    prompt = build_prompt(payload, ("Ann", "Narrator"))
+
+    assert "Ann" in prompt
+    assert "Narrator" in prompt
+    assert payload.model_dump_json() in prompt

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_chunking.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_chunking.py
@@ -1,0 +1,339 @@
+"""Tests for dialogue payload chunking and proposal merging."""
+
+from __future__ import annotations
+
+from automations.ln_voice_over_v2.stages.dialogue.agent import (
+    CandidateDecision,
+    DialogueProposal,
+)
+from automations.ln_voice_over_v2.stages.dialogue.chunking import (
+    attribute_with_chunking,
+    merge_proposals,
+    split_payload,
+)
+from automations.ln_voice_over_v2.stages.dialogue.context import (
+    ChapterPayload,
+    PayloadSegment,
+)
+
+
+def test_split_payload_returns_identity_when_within_cap() -> None:
+    """Payloads already within the cap are passed through unchanged."""
+    payload = _payload(candidate_count=2)
+
+    chunks = split_payload(payload, max_candidates_per_chunk=2)
+
+    assert chunks == [payload]
+    assert chunks[0] is payload
+
+
+def test_split_payload_partitions_candidates_and_keeps_narration() -> None:
+    """Oversized payloads split into ordered, disjoint candidate windows."""
+    payload = _payload(candidate_count=5, narrator_hint="Ayanokouji")
+
+    chunks = split_payload(
+        payload,
+        max_candidates_per_chunk=2,
+        context_overlap_segments=1,
+    )
+
+    assert [candidate_id for chunk in chunks for candidate_id in chunk.candidate_ids] == list(
+        payload.candidate_ids
+    )
+    assert len({candidate_id for chunk in chunks for candidate_id in chunk.candidate_ids}) == 5
+    assert [len(chunk.candidate_ids) for chunk in chunks] == [2, 2, 1]
+    assert all(len(chunk.candidate_ids) <= 2 for chunk in chunks)
+    assert all(chunk.series == payload.series for chunk in chunks)
+    assert all(chunk.volume == payload.volume for chunk in chunks)
+    assert all(chunk.chapter_id == payload.chapter_id for chunk in chunks)
+    assert all(chunk.narrator_hint == "Ayanokouji" for chunk in chunks)
+    assert any(segment.role == "narration" for segment in chunks[0].segments)
+    assert any(segment.role == "narration" for segment in chunks[1].segments)
+
+
+def test_split_payload_tags_lead_in_context_and_excludes_it_from_candidates() -> None:
+    """Lead-in overlap is rebuilt as context and never owned by the next chunk."""
+    payload = _payload(candidate_count=4)
+
+    chunks = split_payload(
+        payload,
+        max_candidates_per_chunk=2,
+        context_overlap_segments=3,
+    )
+
+    assert all(segment.role != "context" for segment in chunks[0].segments)
+    assert all(segment.role == "context" for segment in chunks[1].segments[:3])
+    assert tuple(segment.segment_id for segment in chunks[1].segments[:3]) == (
+        "seg_000002",
+        "seg_000003",
+        "seg_000004",
+    )
+    assert tuple(segment.text for segment in chunks[1].segments[:3]) == tuple(
+        segment.text for segment in payload.segments[1:4]
+    )
+    assert chunks[1].candidate_ids == ("seg_000005", "seg_000007")
+    assert all(
+        segment.segment_id not in chunks[1].candidate_ids for segment in chunks[1].segments[:3]
+    )
+    assert chunks[1].segments[0] is not payload.segments[1]
+
+
+def test_split_payload_with_zero_overlap_is_clean_partition() -> None:
+    """Disabling overlap leaves no context prefix between chunks."""
+    payload = _payload(candidate_count=4)
+
+    chunks = split_payload(
+        payload,
+        max_candidates_per_chunk=2,
+        context_overlap_segments=0,
+    )
+
+    assert all(segment.role != "context" for chunk in chunks for segment in chunk.segments)
+    assert chunks[0].candidate_ids == ("seg_000001", "seg_000003")
+    assert chunks[1].candidate_ids == ("seg_000005", "seg_000007")
+    assert tuple(segment.segment_id for chunk in chunks for segment in chunk.segments) == tuple(
+        segment.segment_id for segment in payload.segments
+    )
+
+
+def test_split_payload_handles_cap_one_and_exact_multiple() -> None:
+    """Cap-one and exact-multiple splits do not create empty chunks."""
+    cap_one = split_payload(
+        _payload(candidate_count=3),
+        max_candidates_per_chunk=1,
+        context_overlap_segments=0,
+    )
+    exact_multiple = split_payload(
+        _payload(candidate_count=4),
+        max_candidates_per_chunk=2,
+        context_overlap_segments=0,
+    )
+
+    assert [chunk.candidate_ids for chunk in cap_one] == [
+        ("seg_000001",),
+        ("seg_000003",),
+        ("seg_000005",),
+    ]
+    assert [chunk.candidate_ids for chunk in exact_multiple] == [
+        ("seg_000001", "seg_000003"),
+        ("seg_000005", "seg_000007"),
+    ]
+
+
+def test_merge_proposals_unions_identical_duplicates_and_conflicts() -> None:
+    """Merge keeps first decisions while surfacing conflicting duplicates."""
+    first = proposal(
+        narrator_raw="Alice",
+        decisions=[
+            decision("seg_000001", speaker_raw="Alice"),
+            decision("seg_000002", speaker_raw="Bob"),
+        ],
+        review_notes=("keep", "duplicate-note"),
+    )
+    second = proposal(
+        narrator_raw="Bob",
+        decisions=[
+            decision("seg_000001", speaker_raw="Alice", reason="same is fine"),
+            decision("seg_000002", speaker_raw="Alice"),
+            decision("seg_000003", is_dialogue=False, reason="thought"),
+        ],
+        review_notes=("duplicate-note", "later"),
+    )
+
+    merged = merge_proposals([first, second])
+
+    assert [decision.segment_id for decision in merged.decisions] == [
+        "seg_000001",
+        "seg_000002",
+        "seg_000003",
+    ]
+    assert merged.decisions[1].speaker_raw == "Bob"
+    assert merged.review_notes == (
+        "keep",
+        "duplicate-note",
+        "later",
+        "conflicting decisions across chunks for seg_000002; kept first",
+    )
+
+
+def test_merge_proposals_picks_narrator_majority_tie_and_all_null() -> None:
+    """Narrator merge uses non-null majority and earliest chunk for ties."""
+    assert (
+        merge_proposals(
+            [
+                proposal(narrator_raw="Alice"),
+                proposal(narrator_raw="Bob"),
+                proposal(narrator_raw="Bob"),
+            ]
+        ).narrator_raw
+        == "Bob"
+    )
+    assert (
+        merge_proposals(
+            [
+                proposal(narrator_raw="Alice"),
+                proposal(narrator_raw=None),
+                proposal(narrator_raw="Bob"),
+            ]
+        ).narrator_raw
+        == "Alice"
+    )
+    assert (
+        merge_proposals(
+            [
+                proposal(narrator_raw="Alice"),
+                proposal(narrator_raw="Bob"),
+                proposal(narrator_raw="Bob"),
+                proposal(narrator_raw="Alice"),
+            ]
+        ).narrator_raw
+        == "Alice"
+    )
+    assert (
+        merge_proposals(
+            [
+                proposal(narrator_raw=None),
+                proposal(narrator_raw=None),
+            ]
+        ).narrator_raw
+        is None
+    )
+
+
+def test_attribute_with_chunking_single_chunk_passthrough() -> None:
+    """Within-cap payloads call the attribute function once with the original object."""
+    payload = _payload(candidate_count=2)
+    calls: list[ChapterPayload] = []
+    expected = proposal(
+        decisions=[
+            decision("seg_000001", speaker_raw="Alice"),
+            decision("seg_000003", speaker_raw="Bob"),
+        ]
+    )
+
+    def attribute_chunk(chunk: ChapterPayload) -> DialogueProposal:
+        calls.append(chunk)
+        return expected
+
+    result = attribute_with_chunking(
+        payload,
+        attribute_chunk=attribute_chunk,
+        max_candidates_per_chunk=2,
+    )
+
+    assert result == expected
+    assert calls == [payload]
+    assert calls[0] is payload
+
+
+def test_attribute_with_chunking_calls_each_chunk_and_merges() -> None:
+    """Oversized payloads are attributed chunk-by-chunk then merged."""
+    payload = _payload(candidate_count=5)
+    calls: list[ChapterPayload] = []
+    canned = [
+        proposal(
+            narrator_raw="Alice",
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000003", speaker_raw="Bob"),
+            ],
+            review_notes=("first",),
+        ),
+        proposal(
+            narrator_raw="Bob",
+            decisions=[
+                decision("seg_000005", speaker_raw="Alice"),
+                decision("seg_000007", speaker_raw="Bob"),
+            ],
+            review_notes=("second",),
+        ),
+        proposal(
+            narrator_raw="Alice",
+            decisions=[
+                decision("seg_000009", speaker_raw="Alice"),
+            ],
+            review_notes=("first", "third"),
+        ),
+    ]
+
+    def attribute_chunk(chunk: ChapterPayload) -> DialogueProposal:
+        calls.append(chunk)
+        return canned[len(calls) - 1]
+
+    result = attribute_with_chunking(
+        payload,
+        attribute_chunk=attribute_chunk,
+        max_candidates_per_chunk=2,
+        context_overlap_segments=1,
+    )
+
+    assert [chunk.candidate_ids for chunk in calls] == [
+        ("seg_000001", "seg_000003"),
+        ("seg_000005", "seg_000007"),
+        ("seg_000009",),
+    ]
+    assert result == merge_proposals(canned)
+
+
+def _payload(
+    *,
+    candidate_count: int,
+    narrator_hint: str | None = None,
+) -> ChapterPayload:
+    segments: list[PayloadSegment] = []
+    candidate_ids: list[str] = []
+    for index in range(candidate_count):
+        candidate_id = f"seg_{index * 2 + 1:06d}"
+        narration_id = f"seg_{index * 2 + 2:06d}"
+        segments.append(
+            PayloadSegment(
+                segment_id=candidate_id,
+                text=f'"Candidate {index + 1}."',
+                role="candidate",
+            )
+        )
+        segments.append(
+            PayloadSegment(
+                segment_id=narration_id,
+                text=f"Narration {index + 1}.",
+                role="narration",
+            )
+        )
+        candidate_ids.append(candidate_id)
+
+    return ChapterPayload(
+        series="series-one",
+        volume="v1",
+        chapter_id="chapter_01",
+        narrator_hint=narrator_hint,
+        segments=tuple(segments),
+        candidate_ids=tuple(candidate_ids),
+    )
+
+
+def proposal(
+    *,
+    narrator_raw: str | None = "Alice",
+    decisions: list[CandidateDecision] | None = None,
+    review_notes: tuple[str, ...] = (),
+) -> DialogueProposal:
+    return DialogueProposal(
+        narrator_raw=narrator_raw,
+        decisions=tuple(decisions or ()),
+        review_notes=review_notes,
+    )
+
+
+def decision(
+    segment_id: str,
+    *,
+    speaker_raw: str | None = None,
+    is_dialogue: bool = True,
+    reason: str = "",
+) -> CandidateDecision:
+    return CandidateDecision(
+        segment_id=segment_id,
+        is_dialogue=is_dialogue,
+        speaker_raw=speaker_raw,
+        reason=reason,
+    )

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_config.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_config.py
@@ -1,0 +1,39 @@
+"""Config helper tests for the dialogue stage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from automations.ln_voice_over_v2.stages.dialogue.config import load_character_registry
+
+
+def test_load_character_registry_reads_valid_characters_json(tmp_path: Path) -> None:
+    """A valid characters config loads as a character registry."""
+    registry_path = tmp_path / "characters.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "characters": [
+                    {
+                        "name": "Horikita Suzune",
+                        "aliases": ["Horikita"],
+                        "role": "main",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registry = load_character_registry(registry_path)
+
+    assert registry.resolve("Horikita") == "Horikita Suzune"
+
+
+def test_load_character_registry_missing_file_raises(tmp_path: Path) -> None:
+    """A missing characters config raises before any fallback policy can apply."""
+    with pytest.raises(FileNotFoundError):
+        load_character_registry(tmp_path / "missing-characters.json")

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_context.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_context.py
@@ -1,0 +1,78 @@
+"""Context payload tests for the dialogue stage."""
+
+from __future__ import annotations
+
+from automations.ln_voice_over_v2.series.contracts import StoryProfile
+from automations.ln_voice_over_v2.stages.dialogue.context import (
+    build_chapter_payload,
+    select_candidates,
+)
+from automations.ln_voice_over_v2.stages.transform.contracts import Segment, SegmentFile
+
+
+def test_select_candidates_picks_only_quote_candidates() -> None:
+    """Candidate selection honors only explicit `quote_candidate is True` hints."""
+    segment_file = _segment_file()
+
+    candidates = select_candidates(segment_file)
+
+    assert [segment.segment_id for segment in candidates] == ["seg_000002", "seg_000004"]
+
+
+def test_build_chapter_payload_tags_roles_and_preserves_text() -> None:
+    """The chapter payload preserves text and records candidate ids in order."""
+    segment_file = _segment_file()
+    story_profile = StoryProfile(
+        profile_id="default",
+        display_name="Default",
+        rules={"default_narrator": "Ayanokouji Kiyotaka"},
+    )
+
+    payload = build_chapter_payload(segment_file, story_profile)
+
+    assert payload.series == "series-one"
+    assert payload.volume == "v1"
+    assert payload.chapter_id == "chapter_01"
+    assert payload.narrator_hint == "Ayanokouji Kiyotaka"
+    assert payload.candidate_ids == ("seg_000002", "seg_000004")
+    assert [segment.role for segment in payload.segments] == [
+        "narration",
+        "candidate",
+        "narration",
+        "candidate",
+    ]
+    assert [segment.text for segment in payload.segments] == [
+        "The hallway was quiet.",
+        '"What are you planning?"',
+        "I did not answer.",
+        '"Nothing."',
+    ]
+
+
+def _segment_file() -> SegmentFile:
+    return SegmentFile(
+        series="series-one",
+        volume="v1",
+        chapter_id="chapter_01",
+        segments=(
+            Segment(segment_id="seg_000001", order=0, text="The hallway was quiet."),
+            Segment(
+                segment_id="seg_000002",
+                order=1,
+                text='"What are you planning?"',
+                parser_hints={"quote_candidate": True},
+            ),
+            Segment(
+                segment_id="seg_000003",
+                order=2,
+                text="I did not answer.",
+                parser_hints={"quote_candidate": False},
+            ),
+            Segment(
+                segment_id="seg_000004",
+                order=3,
+                text='"Nothing."',
+                parser_hints={"quote_candidate": True},
+            ),
+        ),
+    )

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
@@ -1,0 +1,68 @@
+"""CLI tests for the dialogue stage."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from automations.ln_voice_over_v2.common.errors import (
+    ContractValidationError,
+    ValidationProblem,
+)
+from automations.ln_voice_over_v2.stages.dialogue.__main__ import main
+
+
+def test_cli_success(monkeypatch, capsys):
+    expected_path = Path("/tmp/x/dialogue/chapter_01.json")
+
+    def fake_run_dialogue(config):
+        return SimpleNamespace(dialogue_path=expected_path)
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue",
+        fake_run_dialogue,
+    )
+
+    result = main(["--series", "series-a", "--volume", "v1", "--chapter", "chapter_01"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert captured.out == f"{expected_path}\n"
+
+
+def test_cli_contract_error_exit_2(monkeypatch, capsys):
+    def fake_run_dialogue(config):
+        raise ContractValidationError(
+            [
+                ValidationProblem(
+                    code="unknown_chapter",
+                    message="m",
+                    path="chapter_id",
+                )
+            ]
+        )
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue",
+        fake_run_dialogue,
+    )
+
+    result = main(["--series", "series-a", "--volume", "v1", "--chapter", "chapter_01"])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "unknown_chapter" in captured.err
+
+
+def test_cli_generic_error_exit_1(monkeypatch, capsys):
+    def fake_run_dialogue(config):
+        raise FileNotFoundError("missing characters.json")
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue",
+        fake_run_dialogue,
+    )
+
+    result = main(["--series", "series-a", "--volume", "v1", "--chapter", "chapter_01"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "missing characters.json" in captured.err

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
@@ -47,6 +47,36 @@ def test_cli_passes_timeout_to_config(monkeypatch):
     assert captured["config"].timeout_seconds == 600
 
 
+def test_cli_passes_max_candidates_per_chunk_to_config(monkeypatch):
+    captured = {}
+
+    def fake_run_dialogue(config):
+        captured["config"] = config
+        return SimpleNamespace(dialogue_path=Path("/tmp/x/dialogue/chapter_01.json"))
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue",
+        fake_run_dialogue,
+    )
+
+    main(
+        [
+            "--series",
+            "s",
+            "--volume",
+            "v1",
+            "--chapter",
+            "chapter_01",
+            "--max-candidates-per-chunk",
+            "12",
+        ]
+    )
+    assert captured["config"].max_candidates_per_chunk == 12
+
+    main(["--series", "s", "--volume", "v1", "--chapter", "chapter_01"])
+    assert captured["config"].max_candidates_per_chunk == 300
+
+
 def test_cli_volume_passes_timeout_to_config(monkeypatch):
     captured = {}
 
@@ -69,6 +99,35 @@ def test_cli_volume_passes_timeout_to_config(monkeypatch):
 
     assert result == 0
     assert captured["config"].timeout_seconds == 77
+
+
+def test_cli_volume_passes_max_candidates_per_chunk_to_config(monkeypatch):
+    captured = {}
+
+    class _VolumeResult:
+        outcomes = ()
+        written = 0
+        skipped = 0
+        failed = 0
+
+    def fake_run_volume(config):
+        captured["config"] = config
+        return _VolumeResult()
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue_volume",
+        fake_run_volume,
+    )
+
+    result = main(["--series", "s", "--volume", "v1", "--max-candidates-per-chunk", "17"])
+
+    assert result == 0
+    assert captured["config"].max_candidates_per_chunk == 17
+
+    result = main(["--series", "s", "--volume", "v1"])
+
+    assert result == 0
+    assert captured["config"].max_candidates_per_chunk == 300
 
 
 def test_cli_contract_error_exit_2(monkeypatch, capsys):

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
@@ -66,3 +66,55 @@ def test_cli_generic_error_exit_1(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert result == 1
     assert "missing characters.json" in captured.err
+
+
+def test_cli_runs_whole_volume_when_chapter_omitted(monkeypatch, capsys):
+    class _Inner:
+        skipped = False
+        dialogue_path = Path("/tmp/x/dialogue/chapter_01.json")
+
+    class _Outcome:
+        chapter_id = "chapter_01"
+        error = None
+        result = _Inner()
+
+    class _VolumeResult:
+        outcomes = (_Outcome(),)
+        written = 1
+        skipped = 0
+        failed = 0
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue_volume",
+        lambda config: _VolumeResult(),
+    )
+
+    result = main(["--series", "series-a", "--volume", "v1"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "chapter_01.json" in captured.out
+    assert "1 written" in captured.out
+
+
+def test_cli_volume_returns_1_when_a_chapter_fails(monkeypatch, capsys):
+    class _Outcome:
+        chapter_id = "chapter_02"
+        error = "boom"
+        result = None
+
+    class _VolumeResult:
+        outcomes = (_Outcome(),)
+        written = 0
+        skipped = 0
+        failed = 1
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue_volume",
+        lambda config: _VolumeResult(),
+    )
+
+    result = main(["--series", "series-a", "--volume", "v1"])
+
+    assert result == 1
+    assert "boom" in capsys.readouterr().err

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_main.py
@@ -28,6 +28,49 @@ def test_cli_success(monkeypatch, capsys):
     assert captured.out == f"{expected_path}\n"
 
 
+def test_cli_passes_timeout_to_config(monkeypatch):
+    captured = {}
+
+    def fake_run_dialogue(config):
+        captured["config"] = config
+        return SimpleNamespace(dialogue_path=Path("/tmp/x/dialogue/chapter_01.json"))
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue",
+        fake_run_dialogue,
+    )
+
+    main(["--series", "s", "--volume", "v1", "--chapter", "chapter_01", "--timeout", "42"])
+    assert captured["config"].timeout_seconds == 42
+
+    main(["--series", "s", "--volume", "v1", "--chapter", "chapter_01"])
+    assert captured["config"].timeout_seconds == 600
+
+
+def test_cli_volume_passes_timeout_to_config(monkeypatch):
+    captured = {}
+
+    class _VolumeResult:
+        outcomes = ()
+        written = 0
+        skipped = 0
+        failed = 0
+
+    def fake_run_volume(config):
+        captured["config"] = config
+        return _VolumeResult()
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.__main__.run_dialogue_volume",
+        fake_run_volume,
+    )
+
+    result = main(["--series", "s", "--volume", "v1", "--timeout", "77"])
+
+    assert result == 0
+    assert captured["config"].timeout_seconds == 77
+
+
 def test_cli_contract_error_exit_2(monkeypatch, capsys):
     def fake_run_dialogue(config):
         raise ContractValidationError(

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_names.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_names.py
@@ -1,0 +1,61 @@
+"""Name normalization tests for the dialogue stage."""
+
+from __future__ import annotations
+
+from automations.ln_voice_over_v2.pipeline.validators import UNKNOWN_SPEAKER
+from automations.ln_voice_over_v2.series.contracts import Character, CharacterRegistry
+from automations.ln_voice_over_v2.stages.dialogue.names import (
+    canonical_narrator,
+    canonical_speaker,
+)
+
+
+def test_character_registry_resolve_exact_name_alias_and_miss() -> None:
+    """The registry resolves exact canonical names and aliases only."""
+    registry = _registry()
+
+    assert registry.resolve("Horikita Suzune") == "Horikita Suzune"
+    assert registry.resolve(" Horikita ") == "Horikita Suzune"
+    assert registry.resolve("Unknown Student") is None
+
+
+def test_canonical_speaker_resolves_alias_to_canonical() -> None:
+    """Speaker aliases normalize to canonical names."""
+    assert canonical_speaker("Horikita", _registry()) == "Horikita Suzune"
+
+
+def test_canonical_speaker_unknown_and_empty_values_use_unknown() -> None:
+    """Unresolved, empty, and null speaker labels become `Unknown`."""
+    registry = _registry()
+
+    assert canonical_speaker("Mystery Student", registry) == UNKNOWN_SPEAKER
+    assert canonical_speaker(None, registry) == UNKNOWN_SPEAKER
+    assert canonical_speaker("  ", registry) == UNKNOWN_SPEAKER
+
+
+def test_canonical_speaker_first_person_uses_narrator() -> None:
+    """First-person speaker tags resolve to the already-canonical narrator."""
+    registry = _registry()
+
+    assert (
+        canonical_speaker("I.", registry, narrator="Ayanokouji Kiyotaka") == "Ayanokouji Kiyotaka"
+    )
+
+
+def test_canonical_narrator_resolves_alias_and_miss() -> None:
+    """Narrator aliases normalize, while unresolved labels return `None`."""
+    registry = _registry()
+
+    assert canonical_narrator("Ayanokouji", registry) == "Ayanokouji Kiyotaka"
+    assert canonical_narrator("Mystery Student", registry) is None
+    assert canonical_narrator(None, registry) is None
+    assert canonical_narrator("  ", registry) is None
+
+
+def _registry() -> CharacterRegistry:
+    return CharacterRegistry(
+        characters=(
+            Character(name="Ayanokouji Kiyotaka", aliases=("Ayanokouji",), role="main"),
+            Character(name="Horikita Suzune", aliases=("Horikita",), role="main"),
+        )
+    )

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_prompts.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_prompts.py
@@ -1,0 +1,19 @@
+"""Prompt contract tests for dialogue attribution."""
+
+from __future__ import annotations
+
+from automations.ln_voice_over_v2.stages.dialogue.prompts import DIALOGUE_PROMPT
+
+
+def test_dialogue_prompt_excludes_context_and_narration_from_decisions() -> None:
+    """The prompt forbids decisions for non-owned background segment roles."""
+    assert '"context"' in DIALOGUE_PROMPT
+    assert '"narration"' in DIALOGUE_PROMPT
+    assert "never emit a decision for them" in DIALOGUE_PROMPT
+
+
+def test_dialogue_prompt_uses_narrator_hint_as_default_narrator() -> None:
+    """The prompt tells the model how to use narrator_hint without inventing names."""
+    assert "narrator_hint" in DIALOGUE_PROMPT
+    assert "default narrator" in DIALOGUE_PROMPT
+    assert "explicit in-chapter evidence overrides" in DIALOGUE_PROMPT

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
@@ -20,7 +20,9 @@ from automations.ln_voice_over_v2.stages.dialogue.agent import (
 from automations.ln_voice_over_v2.stages.dialogue.contracts import DialogueChapter
 from automations.ln_voice_over_v2.stages.dialogue.runner import (
     DialogueConfig,
+    DialogueVolumeConfig,
     run_dialogue,
+    run_dialogue_volume,
 )
 from automations.ln_voice_over_v2.stages.transform.contracts import (
     ChapterIndexEntry,
@@ -331,3 +333,134 @@ def write_fixture_tree(
             ),
         ),
     )
+
+
+CHAPTER_TWO = "chapter_02"
+
+
+def _accept_both(_payload: object) -> DialogueProposal:
+    return proposal(
+        decisions=[
+            decision("seg_000001", speaker_raw="Alice"),
+            decision("seg_000002", speaker_raw="Bob"),
+        ]
+    )
+
+
+def write_multi_chapter_tree(tmp_path: Path) -> None:
+    save_json_contract(
+        paths.volume_index_path(tmp_path, SERIES, VOLUME),
+        VolumeIndex(
+            series=SERIES,
+            volume=VOLUME,
+            chapters=(
+                ChapterIndexEntry(
+                    chapter_id=CHAPTER,
+                    order=0,
+                    segments_file=f"segments/{CHAPTER}.json",
+                    display_name="Chapter 1",
+                ),
+                ChapterIndexEntry(
+                    chapter_id=CHAPTER_TWO,
+                    order=1,
+                    segments_file=f"segments/{CHAPTER_TWO}.json",
+                    display_name="Chapter 2",
+                ),
+            ),
+        ),
+    )
+    for chapter_id in (CHAPTER, CHAPTER_TWO):
+        save_json_contract(
+            paths.segment_file_path(tmp_path, SERIES, VOLUME, chapter_id),
+            SegmentFile(
+                series=SERIES,
+                volume=VOLUME,
+                chapter_id=chapter_id,
+                segments=(
+                    Segment(
+                        segment_id="seg_000001",
+                        order=0,
+                        text='"Hello," Alice said.',
+                        parser_hints={"quote_candidate": True},
+                    ),
+                    Segment(
+                        segment_id="seg_000002",
+                        order=1,
+                        text='"Hi," Bob said.',
+                        parser_hints={"quote_candidate": True},
+                    ),
+                ),
+            ),
+        )
+    save_json_contract(
+        paths.characters_config_path(tmp_path, SERIES),
+        CharacterRegistry(
+            characters=(
+                Character(name="Alice", aliases=("Al",)),
+                Character(name="Bob", aliases=("Bobby",)),
+            ),
+        ),
+    )
+
+
+def test_run_dialogue_volume_processes_all_chapters(tmp_path: Path) -> None:
+    write_multi_chapter_tree(tmp_path)
+
+    result = run_dialogue_volume(
+        DialogueVolumeConfig(series=SERIES, volume=VOLUME, data_root=tmp_path, workers=2),
+        attribute_fn=_accept_both,
+    )
+
+    assert [outcome.chapter_id for outcome in result.outcomes] == [CHAPTER, CHAPTER_TWO]
+    assert result.written == 2
+    assert result.skipped == 0
+    assert result.failed == 0
+    assert paths.dialogue_chapter_path(tmp_path, SERIES, VOLUME, CHAPTER).exists()
+    assert paths.dialogue_chapter_path(tmp_path, SERIES, VOLUME, CHAPTER_TWO).exists()
+
+
+def test_run_dialogue_volume_skips_existing_unless_force(tmp_path: Path) -> None:
+    write_multi_chapter_tree(tmp_path)
+
+    first = run_dialogue_volume(
+        DialogueVolumeConfig(series=SERIES, volume=VOLUME, data_root=tmp_path),
+        attribute_fn=_accept_both,
+    )
+    assert first.written == 2
+
+    again = run_dialogue_volume(
+        DialogueVolumeConfig(series=SERIES, volume=VOLUME, data_root=tmp_path),
+        attribute_fn=_accept_both,
+    )
+    assert again.skipped == 2
+    assert again.written == 0
+
+    forced = run_dialogue_volume(
+        DialogueVolumeConfig(series=SERIES, volume=VOLUME, data_root=tmp_path, force=True),
+        attribute_fn=_accept_both,
+    )
+    assert forced.written == 2
+    assert forced.skipped == 0
+
+
+def test_run_dialogue_volume_isolates_per_chapter_failure(tmp_path: Path) -> None:
+    write_multi_chapter_tree(tmp_path)
+
+    def attribute(payload: object) -> DialogueProposal:
+        if getattr(payload, "chapter_id", None) == CHAPTER_TWO:
+            raise RuntimeError("boom")
+        return _accept_both(payload)
+
+    result = run_dialogue_volume(
+        DialogueVolumeConfig(series=SERIES, volume=VOLUME, data_root=tmp_path, workers=2),
+        attribute_fn=attribute,
+    )
+
+    by_id = {outcome.chapter_id: outcome for outcome in result.outcomes}
+    assert by_id[CHAPTER].error is None
+    assert by_id[CHAPTER].result is not None
+    assert by_id[CHAPTER_TWO].result is None
+    assert by_id[CHAPTER_TWO].error is not None
+    assert "boom" in by_id[CHAPTER_TWO].error
+    assert result.written == 1
+    assert result.failed == 1

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
@@ -241,6 +241,37 @@ def test_resolved_alias_does_not_trigger_unknown_review(tmp_path: Path) -> None:
     assert result.dialogue.status is ReviewStatus.ACCEPTED
 
 
+def test_run_dialogue_threads_timeout_to_codex(tmp_path: Path, monkeypatch) -> None:
+    write_fixture_tree(tmp_path)
+    captured = {}
+
+    def fake_run_codex_dialogue(prompt: str, *, timeout_seconds: int) -> DialogueProposal:
+        captured["timeout_seconds"] = timeout_seconds
+        return proposal(
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", speaker_raw="Bob"),
+            ]
+        )
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.runner.run_codex_dialogue",
+        fake_run_codex_dialogue,
+    )
+
+    run_dialogue(
+        DialogueConfig(
+            series=SERIES,
+            volume=VOLUME,
+            chapter_id=CHAPTER,
+            data_root=tmp_path,
+            timeout_seconds=42,
+        ),
+    )
+
+    assert captured["timeout_seconds"] == 42
+
+
 def config(tmp_path: Path) -> DialogueConfig:
     return DialogueConfig(
         series=SERIES,
@@ -464,3 +495,30 @@ def test_run_dialogue_volume_isolates_per_chapter_failure(tmp_path: Path) -> Non
     assert "boom" in by_id[CHAPTER_TWO].error
     assert result.written == 1
     assert result.failed == 1
+
+
+def test_run_dialogue_volume_threads_timeout_to_codex(tmp_path: Path, monkeypatch) -> None:
+    write_multi_chapter_tree(tmp_path)
+    seen = []
+
+    def fake_run_codex_dialogue(prompt: str, *, timeout_seconds: int) -> DialogueProposal:
+        seen.append(timeout_seconds)
+        return _accept_both(None)
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.runner.run_codex_dialogue",
+        fake_run_codex_dialogue,
+    )
+
+    run_dialogue_volume(
+        DialogueVolumeConfig(
+            series=SERIES,
+            volume=VOLUME,
+            data_root=tmp_path,
+            workers=2,
+            timeout_seconds=99,
+        ),
+    )
+
+    assert len(seen) == 2
+    assert all(value == 99 for value in seen)

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
@@ -17,6 +17,7 @@ from automations.ln_voice_over_v2.stages.dialogue.agent import (
     CandidateDecision,
     DialogueProposal,
 )
+from automations.ln_voice_over_v2.stages.dialogue.context import ChapterPayload
 from automations.ln_voice_over_v2.stages.dialogue.contracts import DialogueChapter
 from automations.ln_voice_over_v2.stages.dialogue.runner import (
     DialogueConfig,
@@ -272,6 +273,50 @@ def test_run_dialogue_threads_timeout_to_codex(tmp_path: Path, monkeypatch) -> N
     assert captured["timeout_seconds"] == 42
 
 
+def test_default_dialogue_attribution_chunks_large_payload(tmp_path: Path, monkeypatch) -> None:
+    candidate_ids = write_chunking_fixture_tree(tmp_path, candidate_count=5)
+    seen_chunks: list[ChapterPayload] = []
+    max_candidates_per_chunk = 2
+
+    def fake_run_codex_dialogue(prompt: str, *, timeout_seconds: int) -> DialogueProposal:
+        chunk_json = prompt.rsplit("Chapter payload JSON:\n", maxsplit=1)[1]
+        chunk = ChapterPayload.model_validate_json(chunk_json)
+        seen_chunks.append(chunk)
+        return proposal(
+            decisions=[
+                decision(segment_id, speaker_raw="Alice") for segment_id in chunk.candidate_ids
+            ]
+        )
+
+    monkeypatch.setattr(
+        "automations.ln_voice_over_v2.stages.dialogue.runner.run_codex_dialogue",
+        fake_run_codex_dialogue,
+    )
+
+    result = run_dialogue(
+        DialogueConfig(
+            series=SERIES,
+            volume=VOLUME,
+            chapter_id=CHAPTER,
+            data_root=tmp_path,
+            max_candidates_per_chunk=max_candidates_per_chunk,
+        ),
+    )
+
+    assert [row.segment_id for row in result.dialogue.dialogues] == list(candidate_ids)
+    assert result.dialogue.rejected_candidates == ()
+    assert not any(
+        rejected.reason == "model_omitted" for rejected in result.dialogue.rejected_candidates
+    )
+    assert (
+        len(seen_chunks)
+        == (len(candidate_ids) + max_candidates_per_chunk - 1) // max_candidates_per_chunk
+    )
+    assert [segment_id for chunk in seen_chunks for segment_id in chunk.candidate_ids] == list(
+        candidate_ids
+    )
+
+
 def config(tmp_path: Path) -> DialogueConfig:
     return DialogueConfig(
         series=SERIES,
@@ -364,6 +409,53 @@ def write_fixture_tree(
             ),
         ),
     )
+
+
+def write_chunking_fixture_tree(tmp_path: Path, *, candidate_count: int) -> tuple[str, ...]:
+    candidate_ids = tuple(f"seg_{index + 1:06d}" for index in range(candidate_count))
+
+    save_json_contract(
+        paths.volume_index_path(tmp_path, SERIES, VOLUME),
+        VolumeIndex(
+            series=SERIES,
+            volume=VOLUME,
+            chapters=(
+                ChapterIndexEntry(
+                    chapter_id=CHAPTER,
+                    order=0,
+                    segments_file=f"segments/{CHAPTER}.json",
+                    display_name="Chunked Chapter",
+                ),
+            ),
+        ),
+    )
+    save_json_contract(
+        paths.segment_file_path(tmp_path, SERIES, VOLUME, CHAPTER),
+        SegmentFile(
+            series=SERIES,
+            volume=VOLUME,
+            chapter_id=CHAPTER,
+            segments=tuple(
+                Segment(
+                    segment_id=segment_id,
+                    order=index,
+                    text=f'"Line {index + 1}," Alice said.',
+                    parser_hints={"quote_candidate": True},
+                )
+                for index, segment_id in enumerate(candidate_ids)
+            ),
+        ),
+    )
+    save_json_contract(
+        paths.characters_config_path(tmp_path, SERIES),
+        CharacterRegistry(
+            characters=(
+                Character(name="Alice", aliases=("Al",)),
+                Character(name="Bob", aliases=("Bobby",)),
+            ),
+        ),
+    )
+    return candidate_ids
 
 
 CHAPTER_TWO = "chapter_02"

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_runner.py
@@ -1,0 +1,333 @@
+"""Tests for the dialogue runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from automations.ln_voice_over_v2.common import paths
+from automations.ln_voice_over_v2.common.enums import (
+    PerspectiveStatus,
+    ReviewStatus,
+)
+from automations.ln_voice_over_v2.common.errors import ContractValidationError
+from automations.ln_voice_over_v2.common.json_io import load_json_contract, save_json_contract
+from automations.ln_voice_over_v2.series.contracts import Character, CharacterRegistry
+from automations.ln_voice_over_v2.stages.dialogue.agent import (
+    CandidateDecision,
+    DialogueProposal,
+)
+from automations.ln_voice_over_v2.stages.dialogue.contracts import DialogueChapter
+from automations.ln_voice_over_v2.stages.dialogue.runner import (
+    DialogueConfig,
+    run_dialogue,
+)
+from automations.ln_voice_over_v2.stages.transform.contracts import (
+    ChapterIndexEntry,
+    Segment,
+    SegmentFile,
+    VolumeIndex,
+)
+
+SERIES = "series-a"
+VOLUME = "v01"
+CHAPTER = "chapter_01"
+
+
+def test_valid_dialogue_file_round_trips(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            narrator_raw="Alice",
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", speaker_raw="Bob"),
+            ],
+        ),
+    )
+
+    saved = load_json_contract(result.dialogue_path, DialogueChapter)
+    assert result.skipped is False
+    assert result.accepted_count == 2
+    assert result.rejected_count == 0
+    assert saved == result.dialogue
+    assert saved.status is ReviewStatus.ACCEPTED
+    assert saved.review_required is False
+    assert [row.speaker for row in saved.dialogues] == ["Alice", "Bob"]
+    assert saved.perspective.narrator == "Alice"
+    assert saved.perspective.status is PerspectiveStatus.DETECTED
+
+
+def test_rejected_quote_candidate_records_reason(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", is_dialogue=False, reason="thought"),
+            ],
+        ),
+    )
+
+    assert [(row.segment_id, row.reason) for row in result.dialogue.rejected_candidates] == [
+        ("seg_000002", "thought")
+    ]
+
+
+def test_unknown_speaker_requires_review(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", speaker_raw="Mystery"),
+            ],
+        ),
+    )
+
+    assert [row.speaker for row in result.dialogue.dialogues] == ["Alice", "Unknown"]
+    assert result.review_required is True
+    assert result.dialogue.status is ReviewStatus.NEEDS_REVIEW
+
+
+def test_alias_normalization(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            narrator_raw="Al",
+            decisions=[
+                decision("seg_000001", speaker_raw="Al"),
+                decision("seg_000002", speaker_raw="Bobby"),
+            ],
+        ),
+    )
+
+    assert result.dialogue.perspective.narrator == "Alice"
+    assert [row.speaker for row in result.dialogue.dialogues] == ["Alice", "Bob"]
+
+
+def test_invalid_segment_reference_fails_before_write(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path, segment_chapter_id="chapter_02")
+    dialogue_path = paths.dialogue_chapter_path(tmp_path, SERIES, VOLUME, CHAPTER)
+
+    with pytest.raises(ContractValidationError):
+        run_dialogue(
+            config(tmp_path),
+            attribute_fn=lambda _: proposal(
+                decisions=[
+                    decision("seg_000001", speaker_raw="Alice"),
+                    decision("seg_000002", speaker_raw="Bob"),
+                ]
+            ),
+        )
+
+    assert not dialogue_path.exists()
+
+
+def test_unresolved_narrator_requires_review(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            narrator_raw=None,
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", speaker_raw="Bob"),
+            ],
+        ),
+    )
+
+    assert result.dialogue.perspective.status is PerspectiveStatus.UNSET
+    assert result.dialogue.perspective.narrator is None
+    assert result.review_required is True
+    assert result.dialogue.status is ReviewStatus.NEEDS_REVIEW
+
+
+def test_unknown_chapter_fails_before_model_call(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    def fail_if_called(_):
+        raise AssertionError("attribute_fn should not be called")
+
+    with pytest.raises(ContractValidationError) as exc_info:
+        run_dialogue(
+            DialogueConfig(
+                series=SERIES,
+                volume=VOLUME,
+                chapter_id="chapter_99",
+                data_root=tmp_path,
+            ),
+            attribute_fn=fail_if_called,
+        )
+
+    assert exc_info.value.problems[0].code == "unknown_chapter"
+
+
+def test_omitted_candidate_is_rejected_and_requires_review(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(decisions=[decision("seg_000001", speaker_raw="Alice")]),
+    )
+
+    assert [(row.segment_id, row.reason) for row in result.dialogue.rejected_candidates] == [
+        ("seg_000002", "model_omitted")
+    ]
+    assert result.review_required is True
+
+
+def test_skip_existing_preserves_bytes_and_force_regenerates(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+    first = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", speaker_raw="Bob"),
+            ],
+        ),
+    )
+    original_bytes = first.dialogue_path.read_bytes()
+
+    skipped = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(review_notes=("should not run",)),
+    )
+    assert skipped.skipped is True
+    assert first.dialogue_path.read_bytes() == original_bytes
+
+    forced = run_dialogue(
+        DialogueConfig(SERIES, VOLUME, CHAPTER, data_root=tmp_path, force=True),
+        attribute_fn=lambda _: proposal(
+            review_notes=("forced",),
+            decisions=[
+                decision("seg_000001", speaker_raw="Alice"),
+                decision("seg_000002", speaker_raw="Bob"),
+            ],
+        ),
+    )
+    assert forced.skipped is False
+    assert forced.dialogue.review_notes == ("forced",)
+    assert forced.dialogue_path.read_bytes() != original_bytes
+
+
+def test_resolved_alias_does_not_trigger_unknown_review(tmp_path: Path) -> None:
+    write_fixture_tree(tmp_path)
+
+    result = run_dialogue(
+        config(tmp_path),
+        attribute_fn=lambda _: proposal(
+            narrator_raw="Al",
+            decisions=[
+                decision("seg_000001", speaker_raw="Al"),
+                decision("seg_000002", speaker_raw="Bobby"),
+            ],
+        ),
+    )
+
+    assert result.review_required is False
+    assert result.dialogue.status is ReviewStatus.ACCEPTED
+
+
+def config(tmp_path: Path) -> DialogueConfig:
+    return DialogueConfig(
+        series=SERIES,
+        volume=VOLUME,
+        chapter_id=CHAPTER,
+        data_root=tmp_path,
+    )
+
+
+def proposal(
+    *,
+    narrator_raw: str | None = "Alice",
+    decisions: list[CandidateDecision] | None = None,
+    review_notes: tuple[str, ...] = (),
+) -> DialogueProposal:
+    return DialogueProposal(
+        narrator_raw=narrator_raw,
+        decisions=tuple(decisions or ()),
+        review_notes=review_notes,
+    )
+
+
+def decision(
+    segment_id: str,
+    *,
+    speaker_raw: str | None = None,
+    is_dialogue: bool = True,
+    reason: str = "",
+) -> CandidateDecision:
+    return CandidateDecision(
+        segment_id=segment_id,
+        is_dialogue=is_dialogue,
+        speaker_raw=speaker_raw,
+        reason=reason,
+    )
+
+
+def write_fixture_tree(
+    tmp_path: Path,
+    *,
+    segment_chapter_id: str = CHAPTER,
+) -> None:
+    volume_index_path = paths.volume_index_path(tmp_path, SERIES, VOLUME)
+    segment_path = paths.segment_file_path(tmp_path, SERIES, VOLUME, CHAPTER)
+    characters_path = paths.characters_config_path(tmp_path, SERIES)
+
+    save_json_contract(
+        volume_index_path,
+        VolumeIndex(
+            series=SERIES,
+            volume=VOLUME,
+            chapters=(
+                ChapterIndexEntry(
+                    chapter_id=CHAPTER,
+                    order=0,
+                    segments_file=f"segments/{CHAPTER}.json",
+                    display_name="Chapter 1",
+                ),
+            ),
+        ),
+    )
+    save_json_contract(
+        segment_path,
+        SegmentFile(
+            series=SERIES,
+            volume=VOLUME,
+            chapter_id=segment_chapter_id,
+            segments=(
+                Segment(
+                    segment_id="seg_000001",
+                    order=0,
+                    text='"Hello," Alice said.',
+                    parser_hints={"quote_candidate": True},
+                ),
+                Segment(
+                    segment_id="seg_000002",
+                    order=1,
+                    text='"Hi," Bob said.',
+                    parser_hints={"quote_candidate": True},
+                ),
+            ),
+        ),
+    )
+    save_json_contract(
+        characters_path,
+        CharacterRegistry(
+            characters=(
+                Character(name="Alice", aliases=("Al",)),
+                Character(name="Bob", aliases=("Bobby",)),
+            ),
+        ),
+    )

--- a/tests/automations/ln_voice_over_v2/stages/dialogue/test_validation.py
+++ b/tests/automations/ln_voice_over_v2/stages/dialogue/test_validation.py
@@ -1,0 +1,98 @@
+"""Tests for dialogue artifact validation."""
+
+import pytest
+from automations.ln_voice_over_v2.common.enums import PerspectiveStatus, ReviewStatus
+from automations.ln_voice_over_v2.common.errors import ContractValidationError
+from automations.ln_voice_over_v2.stages.dialogue.contracts import (
+    DialogueChapter,
+    DialogueRow,
+    Perspective,
+    RejectedCandidate,
+)
+from automations.ln_voice_over_v2.stages.dialogue.validation import (
+    validate_dialogue_artifact,
+)
+
+
+def _perspective() -> Perspective:
+    return Perspective(
+        status=PerspectiveStatus.DETECTED,
+        narrator="Narrator",
+    )
+
+
+def _dialogue_chapter(
+    *,
+    dialogues: tuple[DialogueRow, ...] = (),
+    rejected_candidates: tuple[RejectedCandidate, ...] = (),
+    status: ReviewStatus = ReviewStatus.ACCEPTED,
+    review_required: bool = False,
+) -> DialogueChapter:
+    return DialogueChapter(
+        series="series-1",
+        volume="volume-1",
+        chapter_id="chapter_01",
+        dialogues=dialogues,
+        rejected_candidates=rejected_candidates,
+        perspective=_perspective(),
+        status=status,
+        review_required=review_required,
+        review_notes=(),
+    )
+
+
+def _dialogue_row(segment_id: str) -> DialogueRow:
+    return DialogueRow(
+        segment_id=segment_id,
+        speaker="Ann",
+    )
+
+
+def _rejected_candidate(segment_id: str) -> RejectedCandidate:
+    return RejectedCandidate(
+        segment_id=segment_id,
+        reason="quoted narration",
+    )
+
+
+def test_validate_dialogue_artifact_valid_passes():
+    artifact = _dialogue_chapter(
+        dialogues=(_dialogue_row("seg_000001"),),
+        rejected_candidates=(_rejected_candidate("seg_000002"),),
+    )
+
+    validate_dialogue_artifact(artifact, ("seg_000001", "seg_000002"))
+
+
+def test_validate_dialogue_artifact_uncovered_candidate():
+    artifact = _dialogue_chapter(dialogues=(_dialogue_row("seg_000001"),))
+
+    with pytest.raises(ContractValidationError) as exc_info:
+        validate_dialogue_artifact(artifact, ("seg_000001", "seg_000002"))
+
+    assert exc_info.value.problems[0].code == "uncovered_candidate"
+
+
+def test_validate_dialogue_artifact_candidate_in_both():
+    artifact = _dialogue_chapter(
+        dialogues=(_dialogue_row("seg_000001"),),
+        rejected_candidates=(_rejected_candidate("seg_000001"),),
+    )
+
+    with pytest.raises(ContractValidationError) as exc_info:
+        validate_dialogue_artifact(artifact, ("seg_000001",))
+
+    assert exc_info.value.problems[0].code == "candidate_in_both"
+
+
+def test_validate_dialogue_artifact_status_mismatch():
+    artifact = _dialogue_chapter(
+        dialogues=(_dialogue_row("seg_000001"),),
+        status=ReviewStatus.NEEDS_REVIEW,
+        review_required=False,
+    )
+
+    with pytest.raises(ContractValidationError) as exc_info:
+        validate_dialogue_artifact(artifact, ("seg_000001",))
+
+    assert exc_info.value.problems[0].code == "status_mismatch"


### PR DESCRIPTION
## Summary

Implements **Stage 3 (dialogue)** of the LNVO v2 pipeline (prepare → transform → **dialogue** → scenes → generation): detect spoken dialogue, assign speakers, resolve chapter perspective. The model proposes an internal `DialogueProposal`; the runner canonicalizes names and assembles the trusted `DialogueChapter` artifact behind a single trust boundary, with two validators run before every write.

## What's in this branch

- **Model boundary** (`agent.py`): `codex exec` text-only attribution, strict JSON parse, configurable per-call timeout (`--timeout`, default 600s).
- **Runner & assembly** (`runner.py`): restricts decisions to candidate segments, canonicalizes speakers/narrator, computes review state, runs both validators. Injectable `attribute_fn` seam (tests never spawn codex).
- **CLI** (`__main__.py`): single-chapter or whole-volume (parallel `--workers`).
- **Chunking** (`chunking.py`, latest work): oversized chapters are split into candidate-capped contiguous windows (`--max-candidates-per-chunk`, default 300) with a lead-in `"context"`-role overlap, attributed per-window and merged before the (unchanged) assembly. Fixes the output-completeness failure where huge chapters returned zero usable dialogue. Also resolves two prior known issues — cross-chunk decision conflicts are flagged in `review_notes` (no silent last-wins), and `narrator_hint` is now consumed by the prompt.
- **Docs**: `docs/lnvo/03-dialogue.md` (contract, implementation notes, known issues) and `docs/lnvo/runbook.md` (Stage 3 commands).

## Verification

- `ruff check` + `ruff format --check` clean; **210 pytest passed**.
- Real-data acceptance (`classroom-of-the-elite-year-2` v4):
  - **chapter_06** (733 candidates): 0 → **725 dialogues**, 733 → **0** `model_omitted` (the chunking fix).
  - **chapter_07** (707): stays healthy (**692 dialogues**); narrator now resolves to `Ayanokouji Kiyotaka`.

## Known follow-ups

- Known issue **#3** (first-person `I`/`me` precedence in `names.py`) — documented, left open by design.
- Residual `Unknown` speakers are anonymous transmission voices → handled via a default voice at the (not-yet-wired) generation stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)